### PR TITLE
bias on n-dim for sparse

### DIFF
--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/Equality/aldebaran_Cijk_Alik_Bljk_BBS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/Equality/aldebaran_Cijk_Alik_Bljk_BBS_BH_Bias_AH_SAV.yaml
@@ -53,7 +53,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -222,7 +222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -438,7 +438,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -654,7 +654,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -870,7 +870,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1086,7 +1086,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1302,7 +1302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1518,7 +1518,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1734,7 +1734,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1950,7 +1950,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2166,7 +2166,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2382,7 +2382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2598,7 +2598,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2814,7 +2814,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3030,7 +3030,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3246,7 +3246,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3462,7 +3462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3678,7 +3678,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3894,7 +3894,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4110,7 +4110,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4326,7 +4326,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4542,7 +4542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4758,7 +4758,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4974,7 +4974,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5190,7 +5190,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5406,7 +5406,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5838,7 +5838,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6054,7 +6054,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6270,7 +6270,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6486,7 +6486,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6702,7 +6702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6918,7 +6918,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7134,7 +7134,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7350,7 +7350,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7566,7 +7566,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7782,7 +7782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7998,7 +7998,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8214,7 +8214,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8430,7 +8430,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8646,7 +8646,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8862,7 +8862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9078,7 +9078,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9294,7 +9294,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9510,7 +9510,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9726,7 +9726,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9942,7 +9942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10158,7 +10158,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10374,7 +10374,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10590,7 +10590,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10806,7 +10806,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11022,7 +11022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11238,7 +11238,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11454,7 +11454,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11670,7 +11670,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11886,7 +11886,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12102,7 +12102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12318,7 +12318,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12534,7 +12534,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12750,7 +12750,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12966,7 +12966,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13182,7 +13182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13398,7 +13398,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/Equality/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/Equality/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_AH_SAV.yaml
@@ -53,7 +53,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -222,7 +222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -438,7 +438,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -654,7 +654,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -870,7 +870,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1086,7 +1086,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1302,7 +1302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1518,7 +1518,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1734,7 +1734,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1950,7 +1950,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2166,7 +2166,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2382,7 +2382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2598,7 +2598,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2814,7 +2814,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3030,7 +3030,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3246,7 +3246,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3462,7 +3462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3678,7 +3678,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3894,7 +3894,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4110,7 +4110,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4326,7 +4326,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4542,7 +4542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4758,7 +4758,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4974,7 +4974,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5190,7 +5190,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5406,7 +5406,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5838,7 +5838,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6054,7 +6054,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6270,7 +6270,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6486,7 +6486,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6702,7 +6702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6918,7 +6918,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7134,7 +7134,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7350,7 +7350,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7566,7 +7566,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7782,7 +7782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7998,7 +7998,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8214,7 +8214,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8430,7 +8430,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8646,7 +8646,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8862,7 +8862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9078,7 +9078,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9294,7 +9294,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9510,7 +9510,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9726,7 +9726,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9942,7 +9942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10158,7 +10158,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10374,7 +10374,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10590,7 +10590,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10806,7 +10806,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11022,7 +11022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11238,7 +11238,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11454,7 +11454,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11670,7 +11670,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11886,7 +11886,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12102,7 +12102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12318,7 +12318,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12534,7 +12534,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/Equality/aldebaran_Cijk_Alik_Bljk_SB_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/Equality/aldebaran_Cijk_Alik_Bljk_SB_Bias_A_SAV.yaml
@@ -53,7 +53,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -222,7 +222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -438,7 +438,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -654,7 +654,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -870,7 +870,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1086,7 +1086,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1302,7 +1302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1518,7 +1518,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1734,7 +1734,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1950,7 +1950,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2166,7 +2166,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2382,7 +2382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2598,7 +2598,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2814,7 +2814,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3030,7 +3030,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3246,7 +3246,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3462,7 +3462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3678,7 +3678,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3894,7 +3894,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4110,7 +4110,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4326,7 +4326,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4542,7 +4542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4758,7 +4758,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4974,7 +4974,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5190,7 +5190,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5406,7 +5406,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5838,7 +5838,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6054,7 +6054,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6270,7 +6270,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6486,7 +6486,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6702,7 +6702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6918,7 +6918,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7134,7 +7134,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7350,7 +7350,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7566,7 +7566,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7782,7 +7782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7998,7 +7998,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8214,7 +8214,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8430,7 +8430,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8646,7 +8646,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8862,7 +8862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9078,7 +9078,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9294,7 +9294,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9510,7 +9510,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9726,7 +9726,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9942,7 +9942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10158,7 +10158,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10374,7 +10374,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10590,7 +10590,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10806,7 +10806,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11022,7 +11022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11238,7 +11238,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11454,7 +11454,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11670,7 +11670,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11886,7 +11886,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12102,7 +12102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12318,7 +12318,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12534,7 +12534,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12750,7 +12750,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12966,7 +12966,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13182,7 +13182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13398,7 +13398,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13614,7 +13614,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13830,7 +13830,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14046,7 +14046,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HH_BHS_BH_BiasSH_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HH_BHS_BH_BiasSH_AS_SAV_UserArgs.yaml
@@ -67,7 +67,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -272,7 +272,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -531,7 +531,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -790,7 +790,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1049,7 +1049,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1308,7 +1308,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1567,7 +1567,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1826,7 +1826,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2085,7 +2085,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2344,7 +2344,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_I8II_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_I8II_BH_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -259,7 +259,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -507,7 +507,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -755,7 +755,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HH_BHS_BH_BiasSH_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HH_BHS_BH_BiasSH_AS_SAV_UserArgs.yaml
@@ -67,7 +67,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -272,7 +272,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -531,7 +531,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -790,7 +790,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1049,7 +1049,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1308,7 +1308,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1567,7 +1567,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1826,7 +1826,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2085,7 +2085,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Ailk_Bljk_I8II_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Ailk_Bljk_I8II_BH_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -259,7 +259,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -507,7 +507,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -755,7 +755,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1003,7 +1003,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_BBS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_BBS_BH_Bias_AH_SAV.yaml
@@ -53,7 +53,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -222,7 +222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_AH_SAV.yaml
@@ -53,7 +53,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -222,7 +222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HH_BHS_BH_BiasSH_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HH_BHS_BH_BiasSH_AS_SAV_UserArgs.yaml
@@ -67,7 +67,7 @@
   TransposeA: true
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -272,7 +272,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -531,7 +531,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -790,7 +790,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1049,7 +1049,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1308,7 +1308,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1567,7 +1567,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1826,7 +1826,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_I8II_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_I8II_BH_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -259,7 +259,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -507,7 +507,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -755,7 +755,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1003,7 +1003,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_SB_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_SB_Bias_A_SAV.yaml
@@ -53,7 +53,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -222,7 +222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bljk_HH_BHS_BH_BiasSH_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bljk_HH_BHS_BH_BiasSH_AS_SAV_UserArgs.yaml
@@ -67,7 +67,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -272,7 +272,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -531,7 +531,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -790,7 +790,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1049,7 +1049,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1308,7 +1308,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1567,7 +1567,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1826,7 +1826,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2085,7 +2085,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2344,7 +2344,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bljk_I8II_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bljk_I8II_BH_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -259,7 +259,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -507,7 +507,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -755,7 +755,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1003,7 +1003,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Ailk_Bljk_HHS_BH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Ailk_Bljk_HHS_BH.yaml
@@ -53,7 +53,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -222,7 +222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -438,7 +438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -654,7 +654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -870,7 +870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1086,7 +1086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1302,7 +1302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1518,7 +1518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1734,7 +1734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1950,7 +1950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2166,7 +2166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2639,7 +2639,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2855,7 +2855,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3071,7 +3071,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3287,7 +3287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3503,7 +3503,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3719,7 +3719,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3935,7 +3935,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4151,7 +4151,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4367,7 +4367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4582,7 +4582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4797,7 +4797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5013,7 +5013,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5229,7 +5229,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5445,7 +5445,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5660,7 +5660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5876,7 +5876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6091,7 +6091,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6306,7 +6306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6522,7 +6522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6742,7 +6742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6966,7 +6966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7190,7 +7190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7414,7 +7414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7638,7 +7638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_AH_SAV.yaml
@@ -54,7 +54,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -224,7 +224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -441,7 +441,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -658,7 +658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -875,7 +875,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1094,7 +1094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1313,7 +1313,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1530,7 +1530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1747,7 +1747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1964,7 +1964,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2181,7 +2181,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2398,7 +2398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2615,7 +2615,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2832,7 +2832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3049,7 +3049,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3266,7 +3266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3489,7 +3489,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3712,7 +3712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3940,7 +3940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4170,7 +4170,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4396,7 +4396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4619,7 +4619,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4842,7 +4842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5060,7 +5060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5278,7 +5278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5496,7 +5496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5714,7 +5714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5932,7 +5932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Ailk_Bljk_HSS_BH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Ailk_Bljk_HSS_BH.yaml
@@ -53,7 +53,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -222,7 +222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -438,7 +438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -654,7 +654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -870,7 +870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1086,7 +1086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1302,7 +1302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1518,7 +1518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1734,7 +1734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1950,7 +1950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2166,7 +2166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2639,7 +2639,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2855,7 +2855,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3071,7 +3071,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3287,7 +3287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3503,7 +3503,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3719,7 +3719,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3935,7 +3935,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4151,7 +4151,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4367,7 +4367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4582,7 +4582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4797,7 +4797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5013,7 +5013,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5229,7 +5229,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5445,7 +5445,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5660,7 +5660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5876,7 +5876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6091,7 +6091,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6306,7 +6306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6522,7 +6522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6742,7 +6742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6966,7 +6966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7190,7 +7190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7414,7 +7414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7638,7 +7638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Ailk_Bljk_HSS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Ailk_Bljk_HSS_BH_Bias_AH_SAV.yaml
@@ -54,7 +54,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -224,7 +224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -441,7 +441,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -658,7 +658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -875,7 +875,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1094,7 +1094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1313,7 +1313,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1530,7 +1530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1747,7 +1747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1964,7 +1964,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2181,7 +2181,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2398,7 +2398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2615,7 +2615,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2832,7 +2832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3049,7 +3049,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3266,7 +3266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3489,7 +3489,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3712,7 +3712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3940,7 +3940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4170,7 +4170,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4396,7 +4396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4619,7 +4619,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4842,7 +4842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5060,7 +5060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5278,7 +5278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5496,7 +5496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5714,7 +5714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5932,7 +5932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Alik_Bljk_HHS_BH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Alik_Bljk_HHS_BH.yaml
@@ -54,7 +54,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -222,7 +222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -438,7 +438,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -653,7 +653,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -869,7 +869,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1085,7 +1085,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -508,7 +508,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -58,7 +58,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -236,7 +236,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -462,7 +462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -688,7 +688,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -234,7 +234,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -458,7 +458,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -234,7 +234,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -458,7 +458,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -682,7 +682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -58,7 +58,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -236,7 +236,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -462,7 +462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_GG_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_GG_AH_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -228,7 +228,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -447,7 +447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -666,7 +666,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -885,7 +885,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1104,7 +1104,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1323,7 +1323,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1761,7 +1761,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1980,7 +1980,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2199,7 +2199,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2418,7 +2418,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2637,7 +2637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2856,7 +2856,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3075,7 +3075,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3294,7 +3294,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3513,7 +3513,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3732,7 +3732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3951,7 +3951,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4170,7 +4170,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4389,7 +4389,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4608,7 +4608,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4827,7 +4827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5046,7 +5046,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5265,7 +5265,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5484,7 +5484,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5703,7 +5703,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5922,7 +5922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6141,7 +6141,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6360,7 +6360,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6579,7 +6579,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6798,7 +6798,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7017,7 +7017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7236,7 +7236,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7455,7 +7455,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7674,7 +7674,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7893,7 +7893,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8112,7 +8112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8331,7 +8331,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8550,7 +8550,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8769,7 +8769,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8988,7 +8988,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9207,7 +9207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9426,7 +9426,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9645,7 +9645,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9864,7 +9864,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10083,7 +10083,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10302,7 +10302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10521,7 +10521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10740,7 +10740,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10959,7 +10959,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11178,7 +11178,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11397,7 +11397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11616,7 +11616,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11835,7 +11835,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12054,7 +12054,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12273,7 +12273,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12492,7 +12492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12711,7 +12711,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12930,7 +12930,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13149,7 +13149,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13368,7 +13368,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13587,7 +13587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13806,7 +13806,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14025,7 +14025,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14244,7 +14244,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14463,7 +14463,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14682,7 +14682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14901,7 +14901,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15120,7 +15120,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15339,7 +15339,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15558,7 +15558,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15777,7 +15777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15996,7 +15996,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16215,7 +16215,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16434,7 +16434,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16653,7 +16653,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16872,7 +16872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17091,7 +17091,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17310,7 +17310,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17529,7 +17529,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17748,7 +17748,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17967,7 +17967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18186,7 +18186,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18405,7 +18405,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18624,7 +18624,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18843,7 +18843,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19281,7 +19281,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19500,7 +19500,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19719,7 +19719,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19938,7 +19938,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20376,7 +20376,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20595,7 +20595,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20814,7 +20814,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21033,7 +21033,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21252,7 +21252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21471,7 +21471,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21690,7 +21690,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21909,7 +21909,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22128,7 +22128,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22347,7 +22347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22566,7 +22566,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22785,7 +22785,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23004,7 +23004,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23223,7 +23223,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23442,7 +23442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23661,7 +23661,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23880,7 +23880,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24099,7 +24099,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24318,7 +24318,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24537,7 +24537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24756,7 +24756,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24975,7 +24975,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25194,7 +25194,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25413,7 +25413,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25632,7 +25632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25851,7 +25851,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26070,7 +26070,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26289,7 +26289,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26508,7 +26508,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26727,7 +26727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26946,7 +26946,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27165,7 +27165,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27384,7 +27384,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27603,7 +27603,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27822,7 +27822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28041,7 +28041,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28260,7 +28260,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_GG.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_GG.yaml
@@ -55,7 +55,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -225,7 +225,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -442,7 +442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -659,7 +659,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -876,7 +876,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1093,7 +1093,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1310,7 +1310,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1527,7 +1527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1744,7 +1744,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1961,7 +1961,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2178,7 +2178,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2395,7 +2395,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2612,7 +2612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2829,7 +2829,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3046,7 +3046,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3263,7 +3263,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3480,7 +3480,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3697,7 +3697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3914,7 +3914,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4131,7 +4131,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4348,7 +4348,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4565,7 +4565,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4782,7 +4782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4999,7 +4999,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5216,7 +5216,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5433,7 +5433,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5650,7 +5650,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5867,7 +5867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6084,7 +6084,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6301,7 +6301,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6518,7 +6518,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6735,7 +6735,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6952,7 +6952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7169,7 +7169,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7386,7 +7386,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7603,7 +7603,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7820,7 +7820,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8037,7 +8037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8254,7 +8254,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8471,7 +8471,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8688,7 +8688,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8905,7 +8905,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9122,7 +9122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9339,7 +9339,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9556,7 +9556,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9773,7 +9773,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9990,7 +9990,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10207,7 +10207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10424,7 +10424,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10641,7 +10641,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10858,7 +10858,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11075,7 +11075,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11292,7 +11292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11509,7 +11509,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11726,7 +11726,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11943,7 +11943,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12160,7 +12160,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12377,7 +12377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12594,7 +12594,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12811,7 +12811,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13028,7 +13028,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13245,7 +13245,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13462,7 +13462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13679,7 +13679,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13896,7 +13896,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14113,7 +14113,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14330,7 +14330,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14764,7 +14764,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14981,7 +14981,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15198,7 +15198,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15415,7 +15415,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15632,7 +15632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15849,7 +15849,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16066,7 +16066,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16283,7 +16283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16500,7 +16500,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16717,7 +16717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16934,7 +16934,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17151,7 +17151,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17368,7 +17368,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17585,7 +17585,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17802,7 +17802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18019,7 +18019,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18236,7 +18236,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18453,7 +18453,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18670,7 +18670,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18887,7 +18887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19104,7 +19104,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19321,7 +19321,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19538,7 +19538,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19755,7 +19755,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19972,7 +19972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20189,7 +20189,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20406,7 +20406,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20623,7 +20623,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21057,7 +21057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21274,7 +21274,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21491,7 +21491,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21708,7 +21708,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21925,7 +21925,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22142,7 +22142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22359,7 +22359,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22576,7 +22576,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22793,7 +22793,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23010,7 +23010,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23227,7 +23227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23444,7 +23444,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23661,7 +23661,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23878,7 +23878,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24095,7 +24095,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24312,7 +24312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24529,7 +24529,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24746,7 +24746,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24963,7 +24963,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25180,7 +25180,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25397,7 +25397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25614,7 +25614,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25831,7 +25831,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26048,7 +26048,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26265,7 +26265,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26482,7 +26482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26699,7 +26699,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26916,7 +26916,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27133,7 +27133,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27350,7 +27350,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27567,7 +27567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27784,7 +27784,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28001,7 +28001,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HH_BHS_BH_BiasSH_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HH_BHS_BH_BiasSH_AS_SAV_UserArgs.yaml
@@ -67,7 +67,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -272,7 +272,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -531,7 +531,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -790,7 +790,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1049,7 +1049,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1308,7 +1308,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1567,7 +1567,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1826,7 +1826,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2085,7 +2085,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2344,7 +2344,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_AH_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -228,7 +228,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -447,7 +447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -666,7 +666,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -885,7 +885,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1104,7 +1104,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1323,7 +1323,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1761,7 +1761,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1980,7 +1980,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2199,7 +2199,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2418,7 +2418,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2637,7 +2637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2856,7 +2856,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3075,7 +3075,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3294,7 +3294,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3513,7 +3513,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3732,7 +3732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3951,7 +3951,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4170,7 +4170,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4389,7 +4389,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4608,7 +4608,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4827,7 +4827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5046,7 +5046,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5265,7 +5265,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5484,7 +5484,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5703,7 +5703,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5922,7 +5922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6141,7 +6141,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6360,7 +6360,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6579,7 +6579,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6798,7 +6798,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7017,7 +7017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7236,7 +7236,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7455,7 +7455,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7674,7 +7674,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7893,7 +7893,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8112,7 +8112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8331,7 +8331,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8550,7 +8550,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8769,7 +8769,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8988,7 +8988,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9207,7 +9207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9426,7 +9426,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9645,7 +9645,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9864,7 +9864,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10083,7 +10083,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10302,7 +10302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10521,7 +10521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10740,7 +10740,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10959,7 +10959,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11178,7 +11178,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11397,7 +11397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11616,7 +11616,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11835,7 +11835,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12054,7 +12054,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12273,7 +12273,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12492,7 +12492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12711,7 +12711,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12930,7 +12930,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13149,7 +13149,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13368,7 +13368,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13587,7 +13587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13806,7 +13806,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14025,7 +14025,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14244,7 +14244,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14463,7 +14463,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14682,7 +14682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14901,7 +14901,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15120,7 +15120,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15339,7 +15339,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15558,7 +15558,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15777,7 +15777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15996,7 +15996,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16215,7 +16215,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16434,7 +16434,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16653,7 +16653,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16872,7 +16872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17091,7 +17091,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17310,7 +17310,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17529,7 +17529,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17748,7 +17748,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17967,7 +17967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18186,7 +18186,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18405,7 +18405,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18624,7 +18624,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18843,7 +18843,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19281,7 +19281,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19500,7 +19500,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19719,7 +19719,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19938,7 +19938,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20376,7 +20376,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20595,7 +20595,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20814,7 +20814,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21033,7 +21033,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21252,7 +21252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21471,7 +21471,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21690,7 +21690,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21909,7 +21909,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22128,7 +22128,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22347,7 +22347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22566,7 +22566,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22785,7 +22785,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23004,7 +23004,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23223,7 +23223,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23442,7 +23442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23661,7 +23661,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23880,7 +23880,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24099,7 +24099,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24318,7 +24318,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24537,7 +24537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24756,7 +24756,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24975,7 +24975,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25194,7 +25194,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25413,7 +25413,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25632,7 +25632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25851,7 +25851,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26070,7 +26070,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26289,7 +26289,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26508,7 +26508,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26727,7 +26727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26946,7 +26946,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27165,7 +27165,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27384,7 +27384,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27603,7 +27603,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27822,7 +27822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28041,7 +28041,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28260,7 +28260,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HSS_BH_GG.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HSS_BH_GG.yaml
@@ -55,7 +55,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -225,7 +225,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -442,7 +442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -659,7 +659,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -876,7 +876,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1093,7 +1093,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1310,7 +1310,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1527,7 +1527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1744,7 +1744,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1961,7 +1961,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2178,7 +2178,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2395,7 +2395,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2612,7 +2612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2829,7 +2829,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3046,7 +3046,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3263,7 +3263,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3480,7 +3480,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3697,7 +3697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3914,7 +3914,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4131,7 +4131,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4348,7 +4348,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4565,7 +4565,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4782,7 +4782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4999,7 +4999,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5216,7 +5216,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5433,7 +5433,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5650,7 +5650,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5867,7 +5867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6084,7 +6084,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6301,7 +6301,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6518,7 +6518,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6735,7 +6735,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6952,7 +6952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7169,7 +7169,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7386,7 +7386,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7603,7 +7603,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7820,7 +7820,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8037,7 +8037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8254,7 +8254,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8471,7 +8471,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8688,7 +8688,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8905,7 +8905,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9122,7 +9122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9339,7 +9339,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9556,7 +9556,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9773,7 +9773,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9990,7 +9990,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10207,7 +10207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10424,7 +10424,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10641,7 +10641,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10858,7 +10858,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11075,7 +11075,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11292,7 +11292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11509,7 +11509,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11726,7 +11726,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11943,7 +11943,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12160,7 +12160,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12377,7 +12377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12594,7 +12594,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12811,7 +12811,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13028,7 +13028,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13245,7 +13245,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13462,7 +13462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13679,7 +13679,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13896,7 +13896,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14113,7 +14113,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14330,7 +14330,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14764,7 +14764,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14981,7 +14981,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15198,7 +15198,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15415,7 +15415,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15632,7 +15632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15849,7 +15849,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16066,7 +16066,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16283,7 +16283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16500,7 +16500,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16717,7 +16717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16934,7 +16934,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17151,7 +17151,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17368,7 +17368,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17585,7 +17585,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17802,7 +17802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18019,7 +18019,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18236,7 +18236,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18453,7 +18453,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18670,7 +18670,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18887,7 +18887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19104,7 +19104,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19321,7 +19321,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19538,7 +19538,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19755,7 +19755,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19972,7 +19972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20189,7 +20189,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20406,7 +20406,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20623,7 +20623,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21057,7 +21057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21274,7 +21274,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21491,7 +21491,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21708,7 +21708,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21925,7 +21925,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22142,7 +22142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22359,7 +22359,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22576,7 +22576,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22793,7 +22793,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23010,7 +23010,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23227,7 +23227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23444,7 +23444,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23661,7 +23661,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23878,7 +23878,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24095,7 +24095,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24312,7 +24312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24529,7 +24529,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24746,7 +24746,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24963,7 +24963,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25180,7 +25180,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25397,7 +25397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25614,7 +25614,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25831,7 +25831,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26048,7 +26048,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26265,7 +26265,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26482,7 +26482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26699,7 +26699,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26916,7 +26916,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27133,7 +27133,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27350,7 +27350,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27567,7 +27567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27784,7 +27784,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28001,7 +28001,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_DB_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -508,7 +508,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -58,7 +58,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -236,7 +236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -462,7 +462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -688,7 +688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -234,7 +234,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -458,7 +458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -682,7 +682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -234,7 +234,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -458,7 +458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -682,7 +682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -58,7 +58,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -236,7 +236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -462,7 +462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AH_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -228,7 +228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -447,7 +447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -666,7 +666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -885,7 +885,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1104,7 +1104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1323,7 +1323,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1761,7 +1761,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1980,7 +1980,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2199,7 +2199,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2418,7 +2418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2637,7 +2637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2856,7 +2856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3075,7 +3075,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3294,7 +3294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3513,7 +3513,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3732,7 +3732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3951,7 +3951,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4170,7 +4170,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4389,7 +4389,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4608,7 +4608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4827,7 +4827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5046,7 +5046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5265,7 +5265,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5484,7 +5484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5703,7 +5703,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5922,7 +5922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6141,7 +6141,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6360,7 +6360,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6579,7 +6579,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6798,7 +6798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7017,7 +7017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7236,7 +7236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7455,7 +7455,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7674,7 +7674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7893,7 +7893,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8112,7 +8112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8331,7 +8331,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8550,7 +8550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8769,7 +8769,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8988,7 +8988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9207,7 +9207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9426,7 +9426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9645,7 +9645,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9864,7 +9864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10083,7 +10083,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10302,7 +10302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10521,7 +10521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10740,7 +10740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10959,7 +10959,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11178,7 +11178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11397,7 +11397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11616,7 +11616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11835,7 +11835,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12054,7 +12054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12273,7 +12273,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12492,7 +12492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12711,7 +12711,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12930,7 +12930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13149,7 +13149,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13368,7 +13368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13587,7 +13587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13806,7 +13806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14025,7 +14025,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14244,7 +14244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14463,7 +14463,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14682,7 +14682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14901,7 +14901,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15120,7 +15120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15339,7 +15339,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15558,7 +15558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15777,7 +15777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15996,7 +15996,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16215,7 +16215,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16434,7 +16434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16653,7 +16653,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16872,7 +16872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17091,7 +17091,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17310,7 +17310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17529,7 +17529,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17748,7 +17748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17967,7 +17967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18186,7 +18186,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18405,7 +18405,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18624,7 +18624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18843,7 +18843,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19281,7 +19281,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19500,7 +19500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19719,7 +19719,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19938,7 +19938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20376,7 +20376,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20595,7 +20595,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20814,7 +20814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21033,7 +21033,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21252,7 +21252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21471,7 +21471,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21690,7 +21690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21909,7 +21909,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22128,7 +22128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22347,7 +22347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22566,7 +22566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22785,7 +22785,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23004,7 +23004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23223,7 +23223,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23442,7 +23442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23661,7 +23661,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23880,7 +23880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24099,7 +24099,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24318,7 +24318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24537,7 +24537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24756,7 +24756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24975,7 +24975,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25194,7 +25194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25413,7 +25413,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25632,7 +25632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25851,7 +25851,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26070,7 +26070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26289,7 +26289,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26508,7 +26508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26727,7 +26727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26946,7 +26946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27165,7 +27165,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27384,7 +27384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27603,7 +27603,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27822,7 +27822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28041,7 +28041,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28260,7 +28260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28479,7 +28479,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28698,7 +28698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28917,7 +28917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29136,7 +29136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29355,7 +29355,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29574,7 +29574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29793,7 +29793,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30012,7 +30012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30231,7 +30231,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30450,7 +30450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30669,7 +30669,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30888,7 +30888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31107,7 +31107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31326,7 +31326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31545,7 +31545,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31764,7 +31764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31983,7 +31983,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32202,7 +32202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32421,7 +32421,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32640,7 +32640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32859,7 +32859,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33078,7 +33078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33297,7 +33297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33516,7 +33516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33735,7 +33735,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33954,7 +33954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34173,7 +34173,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34392,7 +34392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34611,7 +34611,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34830,7 +34830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35049,7 +35049,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35268,7 +35268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35487,7 +35487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35706,7 +35706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35925,7 +35925,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36144,7 +36144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36363,7 +36363,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36582,7 +36582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36801,7 +36801,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37020,7 +37020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37239,7 +37239,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37458,7 +37458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37677,7 +37677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37896,7 +37896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38115,7 +38115,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38334,7 +38334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38553,7 +38553,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38793,7 +38793,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39041,7 +39041,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39289,7 +39289,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39536,7 +39536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_GG.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_GG.yaml
@@ -55,7 +55,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -225,7 +225,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -442,7 +442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -659,7 +659,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -876,7 +876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1093,7 +1093,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1310,7 +1310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1527,7 +1527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1744,7 +1744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1961,7 +1961,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2178,7 +2178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2395,7 +2395,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2612,7 +2612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2829,7 +2829,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3046,7 +3046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3263,7 +3263,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3480,7 +3480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3697,7 +3697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3914,7 +3914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4131,7 +4131,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4348,7 +4348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4565,7 +4565,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4782,7 +4782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4999,7 +4999,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5216,7 +5216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5433,7 +5433,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5650,7 +5650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5867,7 +5867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6084,7 +6084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6301,7 +6301,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6518,7 +6518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6735,7 +6735,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6952,7 +6952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7169,7 +7169,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7386,7 +7386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7603,7 +7603,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7820,7 +7820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8037,7 +8037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8254,7 +8254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8471,7 +8471,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8688,7 +8688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8905,7 +8905,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9122,7 +9122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9339,7 +9339,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9556,7 +9556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9773,7 +9773,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9990,7 +9990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10207,7 +10207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10424,7 +10424,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10641,7 +10641,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10858,7 +10858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11075,7 +11075,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11292,7 +11292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11509,7 +11509,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11726,7 +11726,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11943,7 +11943,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12160,7 +12160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12377,7 +12377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12594,7 +12594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12811,7 +12811,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13028,7 +13028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13245,7 +13245,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13462,7 +13462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13679,7 +13679,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13896,7 +13896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14113,7 +14113,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14330,7 +14330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14764,7 +14764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14981,7 +14981,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15198,7 +15198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15415,7 +15415,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15632,7 +15632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15849,7 +15849,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16066,7 +16066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16283,7 +16283,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16500,7 +16500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16717,7 +16717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16934,7 +16934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17151,7 +17151,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17368,7 +17368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17585,7 +17585,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17802,7 +17802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18019,7 +18019,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18236,7 +18236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18453,7 +18453,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18670,7 +18670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18887,7 +18887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19104,7 +19104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19321,7 +19321,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19538,7 +19538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19755,7 +19755,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19972,7 +19972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20189,7 +20189,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20406,7 +20406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20623,7 +20623,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21057,7 +21057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21274,7 +21274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21491,7 +21491,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21708,7 +21708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21925,7 +21925,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22142,7 +22142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22359,7 +22359,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22576,7 +22576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22793,7 +22793,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23010,7 +23010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23227,7 +23227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23444,7 +23444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23661,7 +23661,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23878,7 +23878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24095,7 +24095,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24312,7 +24312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24529,7 +24529,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24746,7 +24746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24963,7 +24963,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25180,7 +25180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25397,7 +25397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25614,7 +25614,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25831,7 +25831,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26048,7 +26048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26265,7 +26265,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26482,7 +26482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26699,7 +26699,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26916,7 +26916,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27133,7 +27133,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27350,7 +27350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27567,7 +27567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27784,7 +27784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28001,7 +28001,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28218,7 +28218,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28435,7 +28435,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28652,7 +28652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28869,7 +28869,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29086,7 +29086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29303,7 +29303,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29520,7 +29520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29737,7 +29737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29954,7 +29954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30171,7 +30171,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30388,7 +30388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30605,7 +30605,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30822,7 +30822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31039,7 +31039,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31256,7 +31256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31473,7 +31473,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31690,7 +31690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31907,7 +31907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32124,7 +32124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32341,7 +32341,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32558,7 +32558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32775,7 +32775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32992,7 +32992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33209,7 +33209,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33426,7 +33426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33643,7 +33643,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33860,7 +33860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34077,7 +34077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34294,7 +34294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34511,7 +34511,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34728,7 +34728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34945,7 +34945,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35162,7 +35162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35379,7 +35379,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35596,7 +35596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35813,7 +35813,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36030,7 +36030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36247,7 +36247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36464,7 +36464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36681,7 +36681,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36898,7 +36898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37115,7 +37115,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37332,7 +37332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37549,7 +37549,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37766,7 +37766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37983,7 +37983,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38200,7 +38200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38437,7 +38437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38682,7 +38682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38927,7 +38927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39171,7 +39171,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HH_BHS_BH_BiasSH_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HH_BHS_BH_BiasSH_AS_SAV_UserArgs.yaml
@@ -67,7 +67,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -272,7 +272,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -531,7 +531,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -790,7 +790,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1049,7 +1049,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1308,7 +1308,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1567,7 +1567,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1826,7 +1826,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2085,7 +2085,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AH_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -228,7 +228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -447,7 +447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -666,7 +666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -885,7 +885,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1104,7 +1104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1323,7 +1323,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1761,7 +1761,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1980,7 +1980,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2199,7 +2199,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2418,7 +2418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2637,7 +2637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2856,7 +2856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3075,7 +3075,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3294,7 +3294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3513,7 +3513,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3732,7 +3732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3951,7 +3951,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4170,7 +4170,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4389,7 +4389,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4608,7 +4608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4827,7 +4827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5046,7 +5046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5265,7 +5265,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5484,7 +5484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5703,7 +5703,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5922,7 +5922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6141,7 +6141,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6360,7 +6360,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6579,7 +6579,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6798,7 +6798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7017,7 +7017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7236,7 +7236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7455,7 +7455,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7674,7 +7674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7893,7 +7893,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8112,7 +8112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8331,7 +8331,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8550,7 +8550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8769,7 +8769,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8988,7 +8988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9207,7 +9207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9426,7 +9426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9645,7 +9645,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9864,7 +9864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10083,7 +10083,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10302,7 +10302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10521,7 +10521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10740,7 +10740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10959,7 +10959,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11178,7 +11178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11397,7 +11397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11616,7 +11616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11835,7 +11835,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12054,7 +12054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12273,7 +12273,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12492,7 +12492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12711,7 +12711,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12930,7 +12930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13149,7 +13149,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13368,7 +13368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13587,7 +13587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13806,7 +13806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14025,7 +14025,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14244,7 +14244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14463,7 +14463,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14682,7 +14682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14901,7 +14901,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15120,7 +15120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15339,7 +15339,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15558,7 +15558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15777,7 +15777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15996,7 +15996,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16215,7 +16215,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16434,7 +16434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16653,7 +16653,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16872,7 +16872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17091,7 +17091,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17310,7 +17310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17529,7 +17529,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17748,7 +17748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17967,7 +17967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18186,7 +18186,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18405,7 +18405,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18624,7 +18624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18843,7 +18843,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19281,7 +19281,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19500,7 +19500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19719,7 +19719,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19938,7 +19938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20376,7 +20376,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20595,7 +20595,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20814,7 +20814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21033,7 +21033,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21252,7 +21252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21471,7 +21471,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21690,7 +21690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21909,7 +21909,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22128,7 +22128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22347,7 +22347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22566,7 +22566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22785,7 +22785,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23004,7 +23004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23223,7 +23223,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23442,7 +23442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23661,7 +23661,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23880,7 +23880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24099,7 +24099,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24318,7 +24318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24537,7 +24537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24756,7 +24756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24975,7 +24975,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25194,7 +25194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25413,7 +25413,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25632,7 +25632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25851,7 +25851,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26070,7 +26070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26289,7 +26289,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26508,7 +26508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26727,7 +26727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26946,7 +26946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27165,7 +27165,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27384,7 +27384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27603,7 +27603,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27822,7 +27822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28041,7 +28041,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28260,7 +28260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28479,7 +28479,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28698,7 +28698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28917,7 +28917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29136,7 +29136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29355,7 +29355,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29574,7 +29574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29793,7 +29793,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30012,7 +30012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30231,7 +30231,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30450,7 +30450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30669,7 +30669,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30888,7 +30888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31107,7 +31107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31326,7 +31326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31545,7 +31545,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31764,7 +31764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31983,7 +31983,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32202,7 +32202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32421,7 +32421,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32640,7 +32640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32859,7 +32859,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33078,7 +33078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33297,7 +33297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33516,7 +33516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33735,7 +33735,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33954,7 +33954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34173,7 +34173,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34392,7 +34392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34611,7 +34611,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34830,7 +34830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35049,7 +35049,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35268,7 +35268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35487,7 +35487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35706,7 +35706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35925,7 +35925,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36144,7 +36144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36363,7 +36363,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36582,7 +36582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36801,7 +36801,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37020,7 +37020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37239,7 +37239,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37458,7 +37458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37677,7 +37677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37896,7 +37896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38115,7 +38115,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38334,7 +38334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38553,7 +38553,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38793,7 +38793,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39041,7 +39041,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39289,7 +39289,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39536,7 +39536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HSS_BH_GG.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HSS_BH_GG.yaml
@@ -55,7 +55,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -225,7 +225,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -442,7 +442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -659,7 +659,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -876,7 +876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1093,7 +1093,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1310,7 +1310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1527,7 +1527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1744,7 +1744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1961,7 +1961,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2178,7 +2178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2395,7 +2395,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2612,7 +2612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2829,7 +2829,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3046,7 +3046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3263,7 +3263,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3480,7 +3480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3697,7 +3697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3914,7 +3914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4131,7 +4131,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4348,7 +4348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4565,7 +4565,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4782,7 +4782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4999,7 +4999,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5216,7 +5216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5433,7 +5433,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5650,7 +5650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5867,7 +5867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6084,7 +6084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6301,7 +6301,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6518,7 +6518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6735,7 +6735,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6952,7 +6952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7169,7 +7169,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7386,7 +7386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7603,7 +7603,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7820,7 +7820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8037,7 +8037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8254,7 +8254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8471,7 +8471,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8688,7 +8688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8905,7 +8905,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9122,7 +9122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9339,7 +9339,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9556,7 +9556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9773,7 +9773,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9990,7 +9990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10207,7 +10207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10424,7 +10424,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10641,7 +10641,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10858,7 +10858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11075,7 +11075,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11292,7 +11292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11509,7 +11509,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11726,7 +11726,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11943,7 +11943,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12160,7 +12160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12377,7 +12377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12594,7 +12594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12811,7 +12811,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13028,7 +13028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13245,7 +13245,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13462,7 +13462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13679,7 +13679,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13896,7 +13896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14113,7 +14113,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14330,7 +14330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14764,7 +14764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14981,7 +14981,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15198,7 +15198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15415,7 +15415,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15632,7 +15632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15849,7 +15849,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16066,7 +16066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16283,7 +16283,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16500,7 +16500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16717,7 +16717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16934,7 +16934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17151,7 +17151,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17368,7 +17368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17585,7 +17585,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17802,7 +17802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18019,7 +18019,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18236,7 +18236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18453,7 +18453,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18670,7 +18670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18887,7 +18887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19104,7 +19104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19321,7 +19321,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19538,7 +19538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19755,7 +19755,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19972,7 +19972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20189,7 +20189,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20406,7 +20406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20623,7 +20623,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21057,7 +21057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21274,7 +21274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21491,7 +21491,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21708,7 +21708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21925,7 +21925,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22142,7 +22142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22359,7 +22359,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22576,7 +22576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22793,7 +22793,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23010,7 +23010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23227,7 +23227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23444,7 +23444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23661,7 +23661,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23878,7 +23878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24095,7 +24095,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24312,7 +24312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24529,7 +24529,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24746,7 +24746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24963,7 +24963,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25180,7 +25180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25397,7 +25397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25614,7 +25614,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25831,7 +25831,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26048,7 +26048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26265,7 +26265,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26482,7 +26482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26699,7 +26699,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26916,7 +26916,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27133,7 +27133,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27350,7 +27350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27567,7 +27567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27784,7 +27784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28001,7 +28001,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28218,7 +28218,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28435,7 +28435,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28652,7 +28652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28869,7 +28869,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29086,7 +29086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29303,7 +29303,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29520,7 +29520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29737,7 +29737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29954,7 +29954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30171,7 +30171,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30388,7 +30388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30605,7 +30605,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30822,7 +30822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31039,7 +31039,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31256,7 +31256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31473,7 +31473,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31690,7 +31690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31907,7 +31907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32124,7 +32124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32341,7 +32341,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32558,7 +32558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32775,7 +32775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32992,7 +32992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33209,7 +33209,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33426,7 +33426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33643,7 +33643,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33860,7 +33860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34077,7 +34077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34294,7 +34294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34511,7 +34511,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34728,7 +34728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34945,7 +34945,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35162,7 +35162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35379,7 +35379,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35596,7 +35596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35813,7 +35813,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36030,7 +36030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36247,7 +36247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36464,7 +36464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36681,7 +36681,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36898,7 +36898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37115,7 +37115,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37332,7 +37332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37549,7 +37549,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37766,7 +37766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37983,7 +37983,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38200,7 +38200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38437,7 +38437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38682,7 +38682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38927,7 +38927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39171,7 +39171,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_BBS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_BBS_BH_Bias_AH_SAV.yaml
@@ -53,7 +53,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -222,7 +222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_DB_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: true
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -508,7 +508,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_AH_SAV.yaml
@@ -53,7 +53,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -222,7 +222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -58,7 +58,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -236,7 +236,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -462,7 +462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -688,7 +688,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -234,7 +234,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -458,7 +458,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -682,7 +682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -234,7 +234,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -458,7 +458,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -58,7 +58,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -236,7 +236,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -462,7 +462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_GG_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_GG_AH_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -228,7 +228,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_GG.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_GG.yaml
@@ -55,7 +55,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -225,7 +225,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HH_BHS_BH_BiasSH_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HH_BHS_BH_BiasSH_AS_SAV_UserArgs.yaml
@@ -67,7 +67,7 @@
   TransposeA: true
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -272,7 +272,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -531,7 +531,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -790,7 +790,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1049,7 +1049,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1308,7 +1308,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1567,7 +1567,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1826,7 +1826,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HSS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HSS_BH_Bias_AH_SAV.yaml
@@ -53,7 +53,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -222,7 +222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_AH_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -228,7 +228,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HSS_BH_GG.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HSS_BH_GG.yaml
@@ -55,7 +55,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -225,7 +225,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_SB_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_SB_Bias_A_SAV.yaml
@@ -53,7 +53,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -222,7 +222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_DB_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -508,7 +508,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -58,7 +58,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -236,7 +236,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -462,7 +462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -688,7 +688,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -234,7 +234,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -458,7 +458,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -234,7 +234,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -458,7 +458,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -683,7 +683,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -58,7 +58,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -236,7 +236,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -462,7 +462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_GG_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_GG_AH_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -228,7 +228,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -447,7 +447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -666,7 +666,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -885,7 +885,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1104,7 +1104,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1323,7 +1323,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1761,7 +1761,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1980,7 +1980,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2199,7 +2199,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2418,7 +2418,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2637,7 +2637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2856,7 +2856,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3075,7 +3075,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3294,7 +3294,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3513,7 +3513,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3732,7 +3732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3951,7 +3951,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4170,7 +4170,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4389,7 +4389,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4608,7 +4608,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4827,7 +4827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5046,7 +5046,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5265,7 +5265,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5484,7 +5484,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5703,7 +5703,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5922,7 +5922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6141,7 +6141,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6360,7 +6360,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6579,7 +6579,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6798,7 +6798,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7017,7 +7017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7236,7 +7236,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7455,7 +7455,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7674,7 +7674,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7893,7 +7893,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8112,7 +8112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8331,7 +8331,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8550,7 +8550,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8769,7 +8769,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8988,7 +8988,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9207,7 +9207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9426,7 +9426,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9645,7 +9645,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9864,7 +9864,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10083,7 +10083,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10302,7 +10302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10521,7 +10521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10740,7 +10740,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10959,7 +10959,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11178,7 +11178,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11397,7 +11397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11616,7 +11616,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11835,7 +11835,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12054,7 +12054,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12273,7 +12273,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12492,7 +12492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12711,7 +12711,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12930,7 +12930,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13149,7 +13149,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13368,7 +13368,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13587,7 +13587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13806,7 +13806,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14025,7 +14025,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14244,7 +14244,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14463,7 +14463,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14682,7 +14682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14901,7 +14901,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15120,7 +15120,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15339,7 +15339,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15558,7 +15558,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15777,7 +15777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15996,7 +15996,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16215,7 +16215,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16434,7 +16434,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16653,7 +16653,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16872,7 +16872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17091,7 +17091,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17310,7 +17310,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17529,7 +17529,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17748,7 +17748,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17967,7 +17967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18186,7 +18186,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18405,7 +18405,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18624,7 +18624,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18843,7 +18843,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19062,7 +19062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19281,7 +19281,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19500,7 +19500,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19719,7 +19719,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19938,7 +19938,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20376,7 +20376,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20595,7 +20595,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20814,7 +20814,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21033,7 +21033,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21252,7 +21252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21471,7 +21471,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21690,7 +21690,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21909,7 +21909,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22128,7 +22128,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22347,7 +22347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22566,7 +22566,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22785,7 +22785,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23004,7 +23004,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23223,7 +23223,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23442,7 +23442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23661,7 +23661,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23880,7 +23880,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24099,7 +24099,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24318,7 +24318,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24537,7 +24537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24756,7 +24756,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24975,7 +24975,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25194,7 +25194,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25413,7 +25413,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25632,7 +25632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25851,7 +25851,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26070,7 +26070,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26289,7 +26289,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26508,7 +26508,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26727,7 +26727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26946,7 +26946,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27165,7 +27165,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27384,7 +27384,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27603,7 +27603,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27822,7 +27822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28041,7 +28041,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28260,7 +28260,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28479,7 +28479,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28698,7 +28698,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28917,7 +28917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29136,7 +29136,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29355,7 +29355,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29574,7 +29574,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29793,7 +29793,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30012,7 +30012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30231,7 +30231,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30450,7 +30450,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30669,7 +30669,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30888,7 +30888,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31107,7 +31107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31326,7 +31326,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31545,7 +31545,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31764,7 +31764,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31983,7 +31983,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32202,7 +32202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32421,7 +32421,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32640,7 +32640,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32859,7 +32859,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33078,7 +33078,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33297,7 +33297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33516,7 +33516,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33735,7 +33735,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33954,7 +33954,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34173,7 +34173,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34392,7 +34392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34611,7 +34611,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34830,7 +34830,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35049,7 +35049,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35268,7 +35268,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35487,7 +35487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35706,7 +35706,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35925,7 +35925,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36144,7 +36144,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36363,7 +36363,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36582,7 +36582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36801,7 +36801,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37020,7 +37020,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37239,7 +37239,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37458,7 +37458,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37677,7 +37677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37896,7 +37896,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38115,7 +38115,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38334,7 +38334,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38553,7 +38553,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38991,7 +38991,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39210,7 +39210,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39429,7 +39429,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39648,7 +39648,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39867,7 +39867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40086,7 +40086,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40305,7 +40305,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40524,7 +40524,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40743,7 +40743,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40962,7 +40962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41181,7 +41181,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41400,7 +41400,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41619,7 +41619,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41838,7 +41838,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42057,7 +42057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42276,7 +42276,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42495,7 +42495,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42714,7 +42714,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42933,7 +42933,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -43152,7 +43152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -43371,7 +43371,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -43590,7 +43590,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -43809,7 +43809,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44028,7 +44028,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44247,7 +44247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44466,7 +44466,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44685,7 +44685,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44904,7 +44904,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45123,7 +45123,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45342,7 +45342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45561,7 +45561,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45780,7 +45780,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45999,7 +45999,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46218,7 +46218,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46437,7 +46437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46656,7 +46656,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46875,7 +46875,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47094,7 +47094,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47313,7 +47313,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47532,7 +47532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47751,7 +47751,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47970,7 +47970,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -48189,7 +48189,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -48408,7 +48408,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -48627,7 +48627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -48846,7 +48846,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49065,7 +49065,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49284,7 +49284,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49503,7 +49503,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49722,7 +49722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49941,7 +49941,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -50160,7 +50160,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -50379,7 +50379,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -50598,7 +50598,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -50817,7 +50817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -51036,7 +51036,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -51255,7 +51255,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -51474,7 +51474,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -51693,7 +51693,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -51933,7 +51933,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52181,7 +52181,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52429,7 +52429,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52676,7 +52676,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_GG.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_GG.yaml
@@ -55,7 +55,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -225,7 +225,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -442,7 +442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -659,7 +659,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -876,7 +876,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1093,7 +1093,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1310,7 +1310,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1527,7 +1527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1744,7 +1744,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1961,7 +1961,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2178,7 +2178,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2395,7 +2395,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2612,7 +2612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2829,7 +2829,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3046,7 +3046,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3263,7 +3263,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3480,7 +3480,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3697,7 +3697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3914,7 +3914,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4131,7 +4131,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4348,7 +4348,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4565,7 +4565,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4782,7 +4782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4999,7 +4999,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5216,7 +5216,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5433,7 +5433,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5650,7 +5650,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5867,7 +5867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6084,7 +6084,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6301,7 +6301,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6518,7 +6518,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6735,7 +6735,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6952,7 +6952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7169,7 +7169,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7386,7 +7386,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7603,7 +7603,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7820,7 +7820,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8037,7 +8037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8254,7 +8254,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8471,7 +8471,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8688,7 +8688,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8905,7 +8905,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9122,7 +9122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9339,7 +9339,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9556,7 +9556,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9773,7 +9773,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9990,7 +9990,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10207,7 +10207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10424,7 +10424,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10641,7 +10641,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10858,7 +10858,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11075,7 +11075,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11292,7 +11292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11509,7 +11509,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11726,7 +11726,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11943,7 +11943,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12160,7 +12160,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12377,7 +12377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12594,7 +12594,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12811,7 +12811,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13028,7 +13028,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13245,7 +13245,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13462,7 +13462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13679,7 +13679,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13896,7 +13896,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14113,7 +14113,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14330,7 +14330,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14764,7 +14764,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14981,7 +14981,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15198,7 +15198,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15415,7 +15415,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15632,7 +15632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15849,7 +15849,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16066,7 +16066,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16283,7 +16283,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16500,7 +16500,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16717,7 +16717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16934,7 +16934,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17151,7 +17151,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17368,7 +17368,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17585,7 +17585,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17802,7 +17802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18019,7 +18019,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18236,7 +18236,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18453,7 +18453,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18670,7 +18670,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18887,7 +18887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19104,7 +19104,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19321,7 +19321,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19538,7 +19538,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19755,7 +19755,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19972,7 +19972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20189,7 +20189,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20406,7 +20406,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20623,7 +20623,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20840,7 +20840,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21057,7 +21057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21274,7 +21274,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21491,7 +21491,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21708,7 +21708,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21925,7 +21925,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22142,7 +22142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22359,7 +22359,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22576,7 +22576,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22793,7 +22793,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23010,7 +23010,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23227,7 +23227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23444,7 +23444,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23661,7 +23661,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23878,7 +23878,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24095,7 +24095,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24312,7 +24312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24529,7 +24529,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24746,7 +24746,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24963,7 +24963,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25180,7 +25180,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25397,7 +25397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25614,7 +25614,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25831,7 +25831,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26048,7 +26048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26265,7 +26265,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26482,7 +26482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26699,7 +26699,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26916,7 +26916,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27133,7 +27133,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27350,7 +27350,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27567,7 +27567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27784,7 +27784,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28001,7 +28001,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28218,7 +28218,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28435,7 +28435,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28652,7 +28652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28869,7 +28869,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29086,7 +29086,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29303,7 +29303,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29520,7 +29520,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29737,7 +29737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29954,7 +29954,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30171,7 +30171,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30388,7 +30388,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30605,7 +30605,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30822,7 +30822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31039,7 +31039,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31256,7 +31256,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31473,7 +31473,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31690,7 +31690,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31907,7 +31907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32124,7 +32124,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32341,7 +32341,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32558,7 +32558,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32775,7 +32775,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32992,7 +32992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33209,7 +33209,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33426,7 +33426,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33643,7 +33643,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33860,7 +33860,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34077,7 +34077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34294,7 +34294,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34511,7 +34511,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34728,7 +34728,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34945,7 +34945,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35162,7 +35162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35379,7 +35379,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35596,7 +35596,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35813,7 +35813,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36030,7 +36030,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36247,7 +36247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36464,7 +36464,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36681,7 +36681,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36898,7 +36898,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37115,7 +37115,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37332,7 +37332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37549,7 +37549,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37766,7 +37766,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37983,7 +37983,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38200,7 +38200,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38417,7 +38417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38634,7 +38634,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38851,7 +38851,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39068,7 +39068,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39285,7 +39285,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39502,7 +39502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39719,7 +39719,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39936,7 +39936,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40153,7 +40153,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40370,7 +40370,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40587,7 +40587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40804,7 +40804,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41021,7 +41021,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41238,7 +41238,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41455,7 +41455,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41672,7 +41672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41889,7 +41889,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42106,7 +42106,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42323,7 +42323,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42540,7 +42540,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42757,7 +42757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42974,7 +42974,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -43191,7 +43191,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -43408,7 +43408,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -43625,7 +43625,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -43842,7 +43842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44059,7 +44059,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44276,7 +44276,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44493,7 +44493,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44710,7 +44710,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44927,7 +44927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45144,7 +45144,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45361,7 +45361,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45578,7 +45578,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45795,7 +45795,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46012,7 +46012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46229,7 +46229,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46446,7 +46446,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46663,7 +46663,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46880,7 +46880,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47097,7 +47097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47314,7 +47314,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47531,7 +47531,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47748,7 +47748,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47965,7 +47965,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -48182,7 +48182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -48399,7 +48399,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -48616,7 +48616,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -48833,7 +48833,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49050,7 +49050,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49267,7 +49267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49484,7 +49484,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49701,7 +49701,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49918,7 +49918,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -50135,7 +50135,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -50352,7 +50352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -50569,7 +50569,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -50786,7 +50786,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -51003,7 +51003,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -51220,7 +51220,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -51457,7 +51457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51702,7 +51702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51947,7 +51947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52191,7 +52191,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HH_BHS_BH_BiasSH_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HH_BHS_BH_BiasSH_AS_SAV_UserArgs.yaml
@@ -67,7 +67,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -272,7 +272,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -531,7 +531,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -790,7 +790,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1049,7 +1049,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1308,7 +1308,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1567,7 +1567,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1826,7 +1826,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2085,7 +2085,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2344,7 +2344,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HSS_BH_Bias_GG_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HSS_BH_Bias_GG_AH_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -228,7 +228,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -447,7 +447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -666,7 +666,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -885,7 +885,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1104,7 +1104,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1323,7 +1323,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1761,7 +1761,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1980,7 +1980,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2199,7 +2199,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2418,7 +2418,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2637,7 +2637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2856,7 +2856,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3075,7 +3075,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3294,7 +3294,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3513,7 +3513,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3732,7 +3732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3951,7 +3951,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4170,7 +4170,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4389,7 +4389,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4608,7 +4608,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4827,7 +4827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5046,7 +5046,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5265,7 +5265,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5484,7 +5484,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5703,7 +5703,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5922,7 +5922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6141,7 +6141,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6360,7 +6360,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6579,7 +6579,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6798,7 +6798,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7017,7 +7017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7236,7 +7236,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7455,7 +7455,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7674,7 +7674,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7893,7 +7893,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8112,7 +8112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8331,7 +8331,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8550,7 +8550,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8769,7 +8769,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8988,7 +8988,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9207,7 +9207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9426,7 +9426,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9645,7 +9645,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9864,7 +9864,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10083,7 +10083,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10302,7 +10302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10521,7 +10521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10740,7 +10740,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10959,7 +10959,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11178,7 +11178,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11397,7 +11397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11616,7 +11616,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11835,7 +11835,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12054,7 +12054,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12273,7 +12273,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12492,7 +12492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12711,7 +12711,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12930,7 +12930,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13149,7 +13149,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13368,7 +13368,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13587,7 +13587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13806,7 +13806,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14025,7 +14025,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14244,7 +14244,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14463,7 +14463,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14682,7 +14682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14901,7 +14901,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15120,7 +15120,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15339,7 +15339,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15558,7 +15558,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15777,7 +15777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15996,7 +15996,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16215,7 +16215,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16434,7 +16434,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16653,7 +16653,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16872,7 +16872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17091,7 +17091,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17310,7 +17310,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17529,7 +17529,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17748,7 +17748,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17967,7 +17967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18186,7 +18186,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18405,7 +18405,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18624,7 +18624,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18843,7 +18843,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19062,7 +19062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19281,7 +19281,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19500,7 +19500,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19719,7 +19719,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19938,7 +19938,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20376,7 +20376,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20595,7 +20595,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20814,7 +20814,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21033,7 +21033,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21252,7 +21252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21471,7 +21471,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21690,7 +21690,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21909,7 +21909,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22128,7 +22128,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22347,7 +22347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22566,7 +22566,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22785,7 +22785,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23004,7 +23004,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23223,7 +23223,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23442,7 +23442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23661,7 +23661,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23880,7 +23880,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24099,7 +24099,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24318,7 +24318,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24537,7 +24537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24756,7 +24756,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24975,7 +24975,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25194,7 +25194,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25413,7 +25413,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25632,7 +25632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25851,7 +25851,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26070,7 +26070,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26289,7 +26289,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26508,7 +26508,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26727,7 +26727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26946,7 +26946,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27165,7 +27165,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27384,7 +27384,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27603,7 +27603,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27822,7 +27822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28041,7 +28041,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28260,7 +28260,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28479,7 +28479,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28698,7 +28698,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28917,7 +28917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29136,7 +29136,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29355,7 +29355,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29574,7 +29574,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29793,7 +29793,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30012,7 +30012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30231,7 +30231,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30450,7 +30450,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30669,7 +30669,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30888,7 +30888,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31107,7 +31107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31326,7 +31326,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31545,7 +31545,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31764,7 +31764,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31983,7 +31983,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32202,7 +32202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32421,7 +32421,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32640,7 +32640,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32859,7 +32859,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33078,7 +33078,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33297,7 +33297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33516,7 +33516,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33735,7 +33735,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33954,7 +33954,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34173,7 +34173,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34392,7 +34392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34611,7 +34611,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34830,7 +34830,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35049,7 +35049,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35268,7 +35268,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35487,7 +35487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35706,7 +35706,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35925,7 +35925,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36144,7 +36144,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36363,7 +36363,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36582,7 +36582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36801,7 +36801,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37020,7 +37020,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37239,7 +37239,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37458,7 +37458,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37677,7 +37677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37896,7 +37896,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38115,7 +38115,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38334,7 +38334,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38553,7 +38553,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38991,7 +38991,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39210,7 +39210,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39429,7 +39429,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39648,7 +39648,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39867,7 +39867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40086,7 +40086,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40305,7 +40305,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40524,7 +40524,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40743,7 +40743,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40962,7 +40962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41181,7 +41181,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41400,7 +41400,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41619,7 +41619,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41838,7 +41838,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42057,7 +42057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42276,7 +42276,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42495,7 +42495,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42714,7 +42714,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42933,7 +42933,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -43152,7 +43152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -43371,7 +43371,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -43590,7 +43590,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -43809,7 +43809,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44028,7 +44028,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44247,7 +44247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44466,7 +44466,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44685,7 +44685,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44904,7 +44904,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45123,7 +45123,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45342,7 +45342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45561,7 +45561,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45780,7 +45780,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45999,7 +45999,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46218,7 +46218,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46437,7 +46437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46656,7 +46656,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46875,7 +46875,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47094,7 +47094,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47313,7 +47313,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47532,7 +47532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47751,7 +47751,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47970,7 +47970,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -48189,7 +48189,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -48408,7 +48408,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -48627,7 +48627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -48846,7 +48846,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49065,7 +49065,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49284,7 +49284,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49503,7 +49503,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49722,7 +49722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49941,7 +49941,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -50160,7 +50160,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -50379,7 +50379,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -50598,7 +50598,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -50817,7 +50817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -51036,7 +51036,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -51255,7 +51255,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -51474,7 +51474,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -51693,7 +51693,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -51933,7 +51933,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52181,7 +52181,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52429,7 +52429,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52676,7 +52676,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HSS_BH_GG.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HSS_BH_GG.yaml
@@ -55,7 +55,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -225,7 +225,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -442,7 +442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -659,7 +659,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -876,7 +876,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1093,7 +1093,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1310,7 +1310,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1527,7 +1527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1744,7 +1744,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1961,7 +1961,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2178,7 +2178,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2395,7 +2395,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2612,7 +2612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2829,7 +2829,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3046,7 +3046,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3263,7 +3263,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3480,7 +3480,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3697,7 +3697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3914,7 +3914,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4131,7 +4131,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4348,7 +4348,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4565,7 +4565,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4782,7 +4782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4999,7 +4999,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5216,7 +5216,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5433,7 +5433,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5650,7 +5650,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5867,7 +5867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6084,7 +6084,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6301,7 +6301,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6518,7 +6518,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6735,7 +6735,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6952,7 +6952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7169,7 +7169,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7386,7 +7386,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7603,7 +7603,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7820,7 +7820,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8037,7 +8037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8254,7 +8254,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8471,7 +8471,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8688,7 +8688,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8905,7 +8905,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9122,7 +9122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9339,7 +9339,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9556,7 +9556,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9773,7 +9773,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -9990,7 +9990,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10207,7 +10207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10424,7 +10424,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10641,7 +10641,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -10858,7 +10858,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11075,7 +11075,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11292,7 +11292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11509,7 +11509,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11726,7 +11726,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -11943,7 +11943,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12160,7 +12160,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12377,7 +12377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12594,7 +12594,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -12811,7 +12811,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13028,7 +13028,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13245,7 +13245,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13462,7 +13462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13679,7 +13679,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -13896,7 +13896,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14113,7 +14113,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14330,7 +14330,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14764,7 +14764,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -14981,7 +14981,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15198,7 +15198,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15415,7 +15415,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15632,7 +15632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -15849,7 +15849,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16066,7 +16066,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16283,7 +16283,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16500,7 +16500,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16717,7 +16717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -16934,7 +16934,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17151,7 +17151,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17368,7 +17368,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17585,7 +17585,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -17802,7 +17802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18019,7 +18019,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18236,7 +18236,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18453,7 +18453,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18670,7 +18670,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -18887,7 +18887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19104,7 +19104,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19321,7 +19321,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19538,7 +19538,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19755,7 +19755,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -19972,7 +19972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20189,7 +20189,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20406,7 +20406,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20623,7 +20623,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -20840,7 +20840,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21057,7 +21057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21274,7 +21274,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21491,7 +21491,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21708,7 +21708,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -21925,7 +21925,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22142,7 +22142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22359,7 +22359,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22576,7 +22576,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -22793,7 +22793,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23010,7 +23010,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23227,7 +23227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23444,7 +23444,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23661,7 +23661,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -23878,7 +23878,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24095,7 +24095,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24312,7 +24312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24529,7 +24529,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24746,7 +24746,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -24963,7 +24963,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25180,7 +25180,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25397,7 +25397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25614,7 +25614,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -25831,7 +25831,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26048,7 +26048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26265,7 +26265,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26482,7 +26482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26699,7 +26699,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -26916,7 +26916,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27133,7 +27133,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27350,7 +27350,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27567,7 +27567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -27784,7 +27784,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28001,7 +28001,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28218,7 +28218,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28435,7 +28435,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28652,7 +28652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -28869,7 +28869,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29086,7 +29086,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29303,7 +29303,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29520,7 +29520,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29737,7 +29737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -29954,7 +29954,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30171,7 +30171,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30388,7 +30388,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30605,7 +30605,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -30822,7 +30822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31039,7 +31039,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31256,7 +31256,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31473,7 +31473,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31690,7 +31690,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -31907,7 +31907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32124,7 +32124,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32341,7 +32341,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32558,7 +32558,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32775,7 +32775,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -32992,7 +32992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33209,7 +33209,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33426,7 +33426,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33643,7 +33643,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -33860,7 +33860,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34077,7 +34077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34294,7 +34294,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34511,7 +34511,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34728,7 +34728,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -34945,7 +34945,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35162,7 +35162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35379,7 +35379,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35596,7 +35596,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -35813,7 +35813,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36030,7 +36030,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36247,7 +36247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36464,7 +36464,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36681,7 +36681,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -36898,7 +36898,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37115,7 +37115,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37332,7 +37332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37549,7 +37549,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37766,7 +37766,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -37983,7 +37983,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38200,7 +38200,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38417,7 +38417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38634,7 +38634,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -38851,7 +38851,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39068,7 +39068,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39285,7 +39285,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39502,7 +39502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39719,7 +39719,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -39936,7 +39936,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40153,7 +40153,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40370,7 +40370,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40587,7 +40587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -40804,7 +40804,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41021,7 +41021,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41238,7 +41238,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41455,7 +41455,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41672,7 +41672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -41889,7 +41889,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42106,7 +42106,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42323,7 +42323,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42540,7 +42540,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42757,7 +42757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -42974,7 +42974,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -43191,7 +43191,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -43408,7 +43408,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -43625,7 +43625,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -43842,7 +43842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44059,7 +44059,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44276,7 +44276,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44493,7 +44493,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44710,7 +44710,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -44927,7 +44927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45144,7 +45144,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45361,7 +45361,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45578,7 +45578,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -45795,7 +45795,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46012,7 +46012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46229,7 +46229,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46446,7 +46446,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46663,7 +46663,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -46880,7 +46880,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47097,7 +47097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47314,7 +47314,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47531,7 +47531,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47748,7 +47748,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -47965,7 +47965,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -48182,7 +48182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -48399,7 +48399,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -48616,7 +48616,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -48833,7 +48833,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49050,7 +49050,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49267,7 +49267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49484,7 +49484,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49701,7 +49701,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -49918,7 +49918,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -50135,7 +50135,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -50352,7 +50352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -50569,7 +50569,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -50786,7 +50786,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -51003,7 +51003,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -51220,7 +51220,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -51457,7 +51457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51702,7 +51702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51947,7 +51947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52191,7 +52191,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH.yaml
@@ -52,7 +52,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -437,7 +437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -653,7 +653,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -869,7 +869,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1085,7 +1085,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1301,7 +1301,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1517,7 +1517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1733,7 +1733,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1949,7 +1949,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2165,7 +2165,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2381,7 +2381,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2597,7 +2597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2813,7 +2813,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3029,7 +3029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3245,7 +3245,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3718,7 +3718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3934,7 +3934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4150,7 +4150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4381,7 +4381,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4618,7 +4618,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4855,7 +4855,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5092,7 +5092,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5329,7 +5329,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5566,7 +5566,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5803,7 +5803,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6040,7 +6040,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6282,7 +6282,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6526,7 +6526,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6770,7 +6770,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7014,7 +7014,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7258,7 +7258,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7502,7 +7502,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7741,7 +7741,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7983,7 +7983,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8227,7 +8227,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8471,7 +8471,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_AH_SAV.yaml
@@ -53,7 +53,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -223,7 +223,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -440,7 +440,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -657,7 +657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -874,7 +874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1092,7 +1092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1310,7 +1310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1527,7 +1527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1744,7 +1744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1961,7 +1961,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2178,7 +2178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2395,7 +2395,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2612,7 +2612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2829,7 +2829,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3046,7 +3046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3263,7 +3263,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3482,7 +3482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3701,7 +3701,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3925,7 +3925,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4151,7 +4151,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4373,7 +4373,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4592,7 +4592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4811,7 +4811,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5029,7 +5029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5247,7 +5247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5465,7 +5465,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5683,7 +5683,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5901,7 +5901,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/Equality/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/Equality/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH.yaml
@@ -52,7 +52,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -437,7 +437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -653,7 +653,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -869,7 +869,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1085,7 +1085,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1301,7 +1301,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1517,7 +1517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1733,7 +1733,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1949,7 +1949,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2165,7 +2165,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2381,7 +2381,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2597,7 +2597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2813,7 +2813,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3029,7 +3029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3245,7 +3245,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3718,7 +3718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3934,7 +3934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4150,7 +4150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4381,7 +4381,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4618,7 +4618,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4855,7 +4855,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5092,7 +5092,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5329,7 +5329,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5566,7 +5566,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5803,7 +5803,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6040,7 +6040,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6282,7 +6282,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6526,7 +6526,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6770,7 +6770,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7014,7 +7014,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7258,7 +7258,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7502,7 +7502,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7741,7 +7741,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7983,7 +7983,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8227,7 +8227,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8471,7 +8471,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/Equality/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/Equality/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_AH_SAV.yaml
@@ -53,7 +53,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -223,7 +223,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -440,7 +440,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -657,7 +657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -874,7 +874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1092,7 +1092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1310,7 +1310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1527,7 +1527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1744,7 +1744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1961,7 +1961,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2178,7 +2178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2395,7 +2395,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2612,7 +2612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2829,7 +2829,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3046,7 +3046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3263,7 +3263,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3482,7 +3482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3701,7 +3701,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3925,7 +3925,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4151,7 +4151,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4373,7 +4373,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4592,7 +4592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4811,7 +4811,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5029,7 +5029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5247,7 +5247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5465,7 +5465,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5683,7 +5683,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5901,7 +5901,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -269,7 +269,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -526,7 +526,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -783,7 +783,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1040,7 +1040,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1297,7 +1297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1554,7 +1554,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1811,7 +1811,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2068,7 +2068,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2325,7 +2325,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2582,7 +2582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2839,7 +2839,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3096,7 +3096,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3353,7 +3353,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3610,7 +3610,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3867,7 +3867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4124,7 +4124,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4381,7 +4381,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4638,7 +4638,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4895,7 +4895,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5152,7 +5152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5409,7 +5409,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5666,7 +5666,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5923,7 +5923,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6180,7 +6180,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6437,7 +6437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6694,7 +6694,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6951,7 +6951,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7208,7 +7208,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7465,7 +7465,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7722,7 +7722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7979,7 +7979,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8236,7 +8236,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8493,7 +8493,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8750,7 +8750,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9007,7 +9007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9264,7 +9264,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9521,7 +9521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9778,7 +9778,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10035,7 +10035,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10292,7 +10292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10549,7 +10549,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10806,7 +10806,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11063,7 +11063,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11320,7 +11320,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11577,7 +11577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11834,7 +11834,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12091,7 +12091,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12348,7 +12348,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12605,7 +12605,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12862,7 +12862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13119,7 +13119,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13376,7 +13376,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13633,7 +13633,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13890,7 +13890,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14147,7 +14147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14404,7 +14404,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14661,7 +14661,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14918,7 +14918,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15175,7 +15175,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15432,7 +15432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15689,7 +15689,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15946,7 +15946,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16203,7 +16203,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16460,7 +16460,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16717,7 +16717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16974,7 +16974,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17231,7 +17231,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17488,7 +17488,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17745,7 +17745,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18002,7 +18002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18259,7 +18259,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18516,7 +18516,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18773,7 +18773,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19030,7 +19030,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19287,7 +19287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19544,7 +19544,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19801,7 +19801,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20058,7 +20058,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20315,7 +20315,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20572,7 +20572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20829,7 +20829,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21086,7 +21086,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21343,7 +21343,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21600,7 +21600,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21857,7 +21857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22114,7 +22114,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22371,7 +22371,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22628,7 +22628,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22885,7 +22885,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23142,7 +23142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23399,7 +23399,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23656,7 +23656,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23913,7 +23913,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24170,7 +24170,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24427,7 +24427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24684,7 +24684,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24941,7 +24941,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25198,7 +25198,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25455,7 +25455,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25712,7 +25712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25969,7 +25969,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26226,7 +26226,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26483,7 +26483,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26740,7 +26740,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26997,7 +26997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27254,7 +27254,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27511,7 +27511,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27768,7 +27768,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28025,7 +28025,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28282,7 +28282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28539,7 +28539,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28796,7 +28796,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29053,7 +29053,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29310,7 +29310,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29567,7 +29567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29824,7 +29824,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30081,7 +30081,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30338,7 +30338,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30595,7 +30595,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30852,7 +30852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31109,7 +31109,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31366,7 +31366,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31623,7 +31623,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31880,7 +31880,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32137,7 +32137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32394,7 +32394,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32651,7 +32651,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32908,7 +32908,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33165,7 +33165,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33422,7 +33422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33679,7 +33679,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33936,7 +33936,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34193,7 +34193,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34450,7 +34450,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34707,7 +34707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34964,7 +34964,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35221,7 +35221,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35478,7 +35478,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35735,7 +35735,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35992,7 +35992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36249,7 +36249,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36506,7 +36506,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36763,7 +36763,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37020,7 +37020,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37277,7 +37277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37534,7 +37534,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37791,7 +37791,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38048,7 +38048,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38305,7 +38305,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38562,7 +38562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38819,7 +38819,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39076,7 +39076,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39333,7 +39333,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39590,7 +39590,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39847,7 +39847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40104,7 +40104,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40361,7 +40361,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40618,7 +40618,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40875,7 +40875,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41132,7 +41132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41389,7 +41389,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41646,7 +41646,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41903,7 +41903,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42160,7 +42160,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42417,7 +42417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42674,7 +42674,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42931,7 +42931,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43188,7 +43188,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43445,7 +43445,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43702,7 +43702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43959,7 +43959,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44216,7 +44216,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44473,7 +44473,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44730,7 +44730,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44987,7 +44987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45244,7 +45244,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45501,7 +45501,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45758,7 +45758,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46015,7 +46015,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46272,7 +46272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46529,7 +46529,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46786,7 +46786,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47043,7 +47043,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47300,7 +47300,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47557,7 +47557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47814,7 +47814,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48071,7 +48071,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48328,7 +48328,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48585,7 +48585,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48842,7 +48842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49099,7 +49099,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49356,7 +49356,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49613,7 +49613,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49870,7 +49870,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50127,7 +50127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50384,7 +50384,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50641,7 +50641,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50898,7 +50898,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51155,7 +51155,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51412,7 +51412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51669,7 +51669,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51926,7 +51926,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52183,7 +52183,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52440,7 +52440,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52697,7 +52697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52954,7 +52954,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53211,7 +53211,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53468,7 +53468,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53725,7 +53725,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53982,7 +53982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54239,7 +54239,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54496,7 +54496,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54753,7 +54753,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55010,7 +55010,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55267,7 +55267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55524,7 +55524,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55781,7 +55781,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56038,7 +56038,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56295,7 +56295,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56552,7 +56552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56809,7 +56809,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57066,7 +57066,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57323,7 +57323,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57580,7 +57580,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57837,7 +57837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58094,7 +58094,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58351,7 +58351,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58608,7 +58608,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58865,7 +58865,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59122,7 +59122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59379,7 +59379,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59636,7 +59636,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59893,7 +59893,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60150,7 +60150,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60407,7 +60407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60664,7 +60664,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60921,7 +60921,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61178,7 +61178,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61435,7 +61435,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61692,7 +61692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61949,7 +61949,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62206,7 +62206,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62463,7 +62463,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62720,7 +62720,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62977,7 +62977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63234,7 +63234,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63491,7 +63491,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63748,7 +63748,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64005,7 +64005,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64262,7 +64262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64519,7 +64519,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64776,7 +64776,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65033,7 +65033,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65804,7 +65804,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66061,7 +66061,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66318,7 +66318,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66575,7 +66575,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66832,7 +66832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67089,7 +67089,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67346,7 +67346,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67603,7 +67603,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67860,7 +67860,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68117,7 +68117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68374,7 +68374,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68631,7 +68631,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68888,7 +68888,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69145,7 +69145,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69402,7 +69402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69659,7 +69659,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69916,7 +69916,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70173,7 +70173,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70430,7 +70430,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70687,7 +70687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70944,7 +70944,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71201,7 +71201,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71458,7 +71458,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71715,7 +71715,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71972,7 +71972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72229,7 +72229,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72486,7 +72486,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72743,7 +72743,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73000,7 +73000,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73257,7 +73257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73514,7 +73514,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73771,7 +73771,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74028,7 +74028,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74285,7 +74285,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74542,7 +74542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74799,7 +74799,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75056,7 +75056,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75313,7 +75313,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75570,7 +75570,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75827,7 +75827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76084,7 +76084,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76341,7 +76341,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76598,7 +76598,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76855,7 +76855,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77112,7 +77112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77369,7 +77369,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77626,7 +77626,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77883,7 +77883,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78140,7 +78140,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78397,7 +78397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78654,7 +78654,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78911,7 +78911,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79168,7 +79168,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79425,7 +79425,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79682,7 +79682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79939,7 +79939,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80196,7 +80196,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80453,7 +80453,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80710,7 +80710,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80967,7 +80967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81224,7 +81224,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81481,7 +81481,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81738,7 +81738,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81995,7 +81995,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82252,7 +82252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82509,7 +82509,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82766,7 +82766,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83023,7 +83023,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83280,7 +83280,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83537,7 +83537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83794,7 +83794,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84051,7 +84051,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84308,7 +84308,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84565,7 +84565,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84822,7 +84822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85079,7 +85079,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85336,7 +85336,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85593,7 +85593,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85850,7 +85850,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86107,7 +86107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86364,7 +86364,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86621,7 +86621,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86878,7 +86878,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87135,7 +87135,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87392,7 +87392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87649,7 +87649,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87906,7 +87906,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88163,7 +88163,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88420,7 +88420,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88677,7 +88677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88934,7 +88934,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89191,7 +89191,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89448,7 +89448,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89705,7 +89705,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89962,7 +89962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90219,7 +90219,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90476,7 +90476,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90733,7 +90733,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90990,7 +90990,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91247,7 +91247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91504,7 +91504,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91761,7 +91761,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92018,7 +92018,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92275,7 +92275,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92532,7 +92532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92789,7 +92789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93046,7 +93046,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93303,7 +93303,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93560,7 +93560,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93817,7 +93817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94074,7 +94074,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94331,7 +94331,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94588,7 +94588,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94845,7 +94845,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95102,7 +95102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95359,7 +95359,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95616,7 +95616,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95873,7 +95873,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96130,7 +96130,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96387,7 +96387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96644,7 +96644,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96901,7 +96901,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97158,7 +97158,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97415,7 +97415,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97672,7 +97672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97929,7 +97929,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98186,7 +98186,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98443,7 +98443,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98700,7 +98700,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98957,7 +98957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99214,7 +99214,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99471,7 +99471,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99728,7 +99728,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99985,7 +99985,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100242,7 +100242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100499,7 +100499,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100756,7 +100756,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101013,7 +101013,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101270,7 +101270,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101527,7 +101527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101784,7 +101784,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102041,7 +102041,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102298,7 +102298,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102555,7 +102555,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102812,7 +102812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103069,7 +103069,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103326,7 +103326,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103583,7 +103583,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103840,7 +103840,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104097,7 +104097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104354,7 +104354,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104611,7 +104611,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104868,7 +104868,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105125,7 +105125,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105382,7 +105382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105639,7 +105639,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105896,7 +105896,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106153,7 +106153,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106410,7 +106410,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106667,7 +106667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106924,7 +106924,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107181,7 +107181,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107438,7 +107438,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107695,7 +107695,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107952,7 +107952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108209,7 +108209,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108466,7 +108466,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108723,7 +108723,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108980,7 +108980,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109237,7 +109237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109494,7 +109494,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109751,7 +109751,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110008,7 +110008,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110265,7 +110265,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110522,7 +110522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110779,7 +110779,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111036,7 +111036,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111293,7 +111293,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111550,7 +111550,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111807,7 +111807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112064,7 +112064,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112321,7 +112321,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112578,7 +112578,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112835,7 +112835,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113092,7 +113092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113349,7 +113349,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113606,7 +113606,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113863,7 +113863,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114120,7 +114120,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114377,7 +114377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114634,7 +114634,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114891,7 +114891,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115148,7 +115148,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115405,7 +115405,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115662,7 +115662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115919,7 +115919,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116176,7 +116176,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116433,7 +116433,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116690,7 +116690,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116947,7 +116947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117204,7 +117204,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117461,7 +117461,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117718,7 +117718,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117975,7 +117975,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118232,7 +118232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118489,7 +118489,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118746,7 +118746,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119003,7 +119003,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119260,7 +119260,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119517,7 +119517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119774,7 +119774,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120031,7 +120031,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120288,7 +120288,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120545,7 +120545,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120802,7 +120802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121059,7 +121059,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121316,7 +121316,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121573,7 +121573,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121830,7 +121830,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122087,7 +122087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122344,7 +122344,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122601,7 +122601,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122858,7 +122858,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123115,7 +123115,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123372,7 +123372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123629,7 +123629,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123886,7 +123886,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124143,7 +124143,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124400,7 +124400,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124657,7 +124657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124914,7 +124914,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125171,7 +125171,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125428,7 +125428,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125685,7 +125685,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125942,7 +125942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126199,7 +126199,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126456,7 +126456,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126713,7 +126713,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126970,7 +126970,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127227,7 +127227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127484,7 +127484,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127741,7 +127741,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127998,7 +127998,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -128255,7 +128255,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -128512,7 +128512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -128769,7 +128769,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129026,7 +129026,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129283,7 +129283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129540,7 +129540,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129797,7 +129797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130054,7 +130054,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130311,7 +130311,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130568,7 +130568,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130825,7 +130825,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131082,7 +131082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131339,7 +131339,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131596,7 +131596,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131853,7 +131853,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132110,7 +132110,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132367,7 +132367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132624,7 +132624,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132881,7 +132881,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133138,7 +133138,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133395,7 +133395,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133652,7 +133652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133909,7 +133909,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134166,7 +134166,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134423,7 +134423,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134680,7 +134680,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134937,7 +134937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135194,7 +135194,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135451,7 +135451,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135708,7 +135708,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135965,7 +135965,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136222,7 +136222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136479,7 +136479,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136736,7 +136736,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136993,7 +136993,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -137250,7 +137250,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -137507,7 +137507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -137764,7 +137764,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138021,7 +138021,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138278,7 +138278,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138535,7 +138535,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138792,7 +138792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139049,7 +139049,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139306,7 +139306,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139563,7 +139563,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139820,7 +139820,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -140077,7 +140077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -140334,7 +140334,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -140591,7 +140591,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -140848,7 +140848,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -141105,7 +141105,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_GG_SAB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_GG_SAB_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_GG_SAB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_GG_SAB_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_GG_SAB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_GG_SAB_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_GG_SAB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_GG_SAB_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_GG_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_GG_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_GG_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_GG_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -259,7 +259,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -507,7 +507,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -687,7 +687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -681,7 +681,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_I8II_BH_AI_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_I8II_BH_AI_SAV_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -264,7 +264,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -516,7 +516,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -768,7 +768,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1020,7 +1020,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1272,7 +1272,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_Aux_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_Aux_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_S_MX_B_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_S_MX_B_Bias_A_SAV.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -256,7 +256,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -506,7 +506,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -755,7 +755,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1005,7 +1005,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_BiasSrcD_GradB_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_BiasSrcD_GradB_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_DB_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -259,7 +259,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -507,7 +507,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1537,7 +1537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1537,7 +1537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1537,7 +1537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -687,7 +687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -681,7 +681,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -681,7 +681,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_I8II_BH_AI_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_I8II_BH_AI_SAV_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -264,7 +264,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -516,7 +516,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -768,7 +768,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1020,7 +1020,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1272,7 +1272,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_Aux_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_Aux_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_A_SAV.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -256,7 +256,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -505,7 +505,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -754,7 +754,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1004,7 +1004,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_BBS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_BBS_BH_Bias_AH_SAV.yaml
@@ -52,7 +52,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_DB_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -259,7 +259,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -507,7 +507,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HHS_BH_Bias_AS_SAB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HHS_BH_Bias_AS_SAB_SAV.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HSS_BH_Bias_AS_SAB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HSS_BH_Bias_AS_SAB_SAV.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_AH_SAV.yaml
@@ -52,7 +52,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -687,7 +687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -681,7 +681,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_AH_SAV.yaml
@@ -52,7 +52,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_I8II_BH_AI_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_I8II_BH_AI_SAV_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: true
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -264,7 +264,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -516,7 +516,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -768,7 +768,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1020,7 +1020,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_A_SAV.yaml
@@ -52,7 +52,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_Aux_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_Aux_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_S_MX_B_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bjlk_S_MX_B_Bias_A_SAV.yaml
@@ -62,7 +62,7 @@
   TransposeA: true
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -256,7 +256,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -506,7 +506,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -755,7 +755,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1566,7 +1566,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_DB_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -259,7 +259,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -507,7 +507,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8BS_BH_BiasB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8BS_BH_BiasB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1298,7 +1298,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1555,7 +1555,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8BS_BH_BiasB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8BS_BH_BiasB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -687,7 +687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -682,7 +682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -264,7 +264,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -516,7 +516,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -768,7 +768,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1020,7 +1020,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_I8II_BH_AI_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_I8II_BH_AI_SAV_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -264,7 +264,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -516,7 +516,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -768,7 +768,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1020,7 +1020,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1272,7 +1272,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_Aux_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_Aux_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_S_MX_B_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx940/GridBased/aquavanjaram_Cijk_Alik_Bljk_S_MX_B_Bias_A_SAV.yaml
@@ -62,7 +62,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -256,7 +256,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -506,7 +506,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -755,7 +755,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1005,7 +1005,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -269,7 +269,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -525,7 +525,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -781,7 +781,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1037,7 +1037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1294,7 +1294,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1551,7 +1551,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1808,7 +1808,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2065,7 +2065,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2322,7 +2322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2579,7 +2579,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bjlk_F8F8S_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bjlk_F8F8S_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1298,7 +1298,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1555,7 +1555,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1812,7 +1812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -269,7 +269,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -525,7 +525,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -781,7 +781,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1037,7 +1037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -269,7 +269,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -525,7 +525,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -781,7 +781,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1038,7 +1038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1295,7 +1295,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1552,7 +1552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1809,7 +1809,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2066,7 +2066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8F8S_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8F8S_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1298,7 +1298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1555,7 +1555,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1812,7 +1812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -54,7 +54,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -228,7 +228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -449,7 +449,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -670,7 +670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -891,7 +891,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1112,7 +1112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1333,7 +1333,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1554,7 +1554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1775,7 +1775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1996,7 +1996,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2217,7 +2217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2438,7 +2438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2659,7 +2659,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2880,7 +2880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3101,7 +3101,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3322,7 +3322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3581,7 +3581,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3810,7 +3810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4031,7 +4031,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4252,7 +4252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4488,7 +4488,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4730,7 +4730,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4972,7 +4972,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5214,7 +5214,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5456,7 +5456,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5698,7 +5698,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5940,7 +5940,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6182,7 +6182,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6429,7 +6429,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6677,7 +6677,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6925,7 +6925,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7173,7 +7173,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7421,7 +7421,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7669,7 +7669,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7912,7 +7912,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8159,7 +8159,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8407,7 +8407,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8655,7 +8655,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8913,7 +8913,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9170,7 +9170,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9427,7 +9427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9684,7 +9684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9941,7 +9941,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10198,7 +10198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10455,7 +10455,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10712,7 +10712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10969,7 +10969,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11226,7 +11226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11483,7 +11483,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11741,7 +11741,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11998,7 +11998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12255,7 +12255,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12512,7 +12512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12770,7 +12770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13028,7 +13028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_custom.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_custom.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -528,7 +528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -786,7 +786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1044,7 +1044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1302,7 +1302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1560,7 +1560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1818,7 +1818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2076,7 +2076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2334,7 +2334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2592,7 +2592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2850,7 +2850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3108,7 +3108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3366,7 +3366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3624,7 +3624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3882,7 +3882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_UserArgs.yaml
@@ -54,7 +54,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -225,7 +225,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -443,7 +443,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -661,7 +661,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -879,7 +879,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1097,7 +1097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1315,7 +1315,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1533,7 +1533,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1751,7 +1751,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1969,7 +1969,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2187,7 +2187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2405,7 +2405,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2623,7 +2623,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2841,7 +2841,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3059,7 +3059,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3277,7 +3277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3754,7 +3754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3972,7 +3972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4190,7 +4190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4423,7 +4423,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4662,7 +4662,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4901,7 +4901,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5140,7 +5140,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5379,7 +5379,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5618,7 +5618,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5857,7 +5857,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6096,7 +6096,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6340,7 +6340,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6586,7 +6586,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6832,7 +6832,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7078,7 +7078,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7324,7 +7324,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7570,7 +7570,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7811,7 +7811,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8055,7 +8055,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8301,7 +8301,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8547,7 +8547,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8796,7 +8796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9053,7 +9053,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9310,7 +9310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9567,7 +9567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9824,7 +9824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10081,7 +10081,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10338,7 +10338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10595,7 +10595,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10852,7 +10852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11109,7 +11109,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11366,7 +11366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11623,7 +11623,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11881,7 +11881,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12138,7 +12138,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12395,7 +12395,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12652,7 +12652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_custom.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_custom.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -528,7 +528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -786,7 +786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1044,7 +1044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1302,7 +1302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1560,7 +1560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1818,7 +1818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2076,7 +2076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2334,7 +2334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2592,7 +2592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2850,7 +2850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3108,7 +3108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3366,7 +3366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3624,7 +3624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3882,7 +3882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -54,7 +54,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -228,7 +228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -449,7 +449,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -670,7 +670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -891,7 +891,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1112,7 +1112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1333,7 +1333,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1554,7 +1554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1775,7 +1775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1996,7 +1996,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2217,7 +2217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2438,7 +2438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2659,7 +2659,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2880,7 +2880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3101,7 +3101,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3322,7 +3322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3581,7 +3581,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3810,7 +3810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4031,7 +4031,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4252,7 +4252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4488,7 +4488,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4730,7 +4730,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4972,7 +4972,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5214,7 +5214,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5456,7 +5456,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5698,7 +5698,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5940,7 +5940,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6182,7 +6182,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6429,7 +6429,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6677,7 +6677,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6925,7 +6925,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7173,7 +7173,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7421,7 +7421,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7669,7 +7669,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7912,7 +7912,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8159,7 +8159,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8407,7 +8407,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8655,7 +8655,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8906,7 +8906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9406,7 +9406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9656,7 +9656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9906,7 +9906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10156,7 +10156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10406,7 +10406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10656,7 +10656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10906,7 +10906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11156,7 +11156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11408,7 +11408,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11660,7 +11660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11912,7 +11912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12164,7 +12164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12416,7 +12416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12668,7 +12668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12920,7 +12920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13172,7 +13172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13424,7 +13424,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13676,7 +13676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13929,7 +13929,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14182,7 +14182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14435,7 +14435,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14688,7 +14688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14941,7 +14941,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15194,7 +15194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15447,7 +15447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_UserArgs.yaml
@@ -54,7 +54,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -225,7 +225,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -443,7 +443,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -661,7 +661,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -879,7 +879,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1097,7 +1097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1315,7 +1315,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1533,7 +1533,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1751,7 +1751,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1969,7 +1969,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2187,7 +2187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2405,7 +2405,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2623,7 +2623,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2841,7 +2841,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3059,7 +3059,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3277,7 +3277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3754,7 +3754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3972,7 +3972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4190,7 +4190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4423,7 +4423,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4662,7 +4662,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4901,7 +4901,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5140,7 +5140,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5379,7 +5379,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5618,7 +5618,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5857,7 +5857,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6096,7 +6096,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6340,7 +6340,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6586,7 +6586,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6832,7 +6832,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7078,7 +7078,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7324,7 +7324,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7570,7 +7570,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7811,7 +7811,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8055,7 +8055,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8301,7 +8301,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8547,7 +8547,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8796,7 +8796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9049,7 +9049,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9305,7 +9305,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9561,7 +9561,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9817,7 +9817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10073,7 +10073,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10329,7 +10329,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10585,7 +10585,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10841,7 +10841,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11097,7 +11097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11353,7 +11353,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11609,7 +11609,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11865,7 +11865,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12121,7 +12121,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12377,7 +12377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12633,7 +12633,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12889,7 +12889,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13145,7 +13145,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13402,7 +13402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13659,7 +13659,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13916,7 +13916,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14173,7 +14173,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14430,7 +14430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14687,7 +14687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14944,7 +14944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15201,7 +15201,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_custom.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_custom.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -274,7 +274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -534,7 +534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -793,7 +793,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1055,7 +1055,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1317,7 +1317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1577,7 +1577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1835,7 +1835,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2093,7 +2093,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2351,7 +2351,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2609,7 +2609,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2867,7 +2867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_AH_SAV.yaml
@@ -53,7 +53,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -223,7 +223,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -440,7 +440,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -657,7 +657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -874,7 +874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1092,7 +1092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1310,7 +1310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1527,7 +1527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1744,7 +1744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1961,7 +1961,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2178,7 +2178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2395,7 +2395,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2612,7 +2612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2829,7 +2829,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3046,7 +3046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3263,7 +3263,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3482,7 +3482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3701,7 +3701,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3925,7 +3925,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4151,7 +4151,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4373,7 +4373,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4592,7 +4592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4811,7 +4811,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5029,7 +5029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5247,7 +5247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5465,7 +5465,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5683,7 +5683,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5901,7 +5901,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_UserArgs.yaml
@@ -52,7 +52,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -437,7 +437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -653,7 +653,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -869,7 +869,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1085,7 +1085,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1301,7 +1301,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1517,7 +1517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1733,7 +1733,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1949,7 +1949,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2165,7 +2165,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2381,7 +2381,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2597,7 +2597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2813,7 +2813,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3029,7 +3029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3245,7 +3245,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3718,7 +3718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3934,7 +3934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4150,7 +4150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4381,7 +4381,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4618,7 +4618,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4855,7 +4855,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5092,7 +5092,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5329,7 +5329,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5566,7 +5566,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5803,7 +5803,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6040,7 +6040,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6282,7 +6282,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6526,7 +6526,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6770,7 +6770,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7014,7 +7014,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7258,7 +7258,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7502,7 +7502,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7741,7 +7741,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7983,7 +7983,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8227,7 +8227,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8471,7 +8471,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8718,7 +8718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8966,7 +8966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9218,7 +9218,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9474,7 +9474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9730,7 +9730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9986,7 +9986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10242,7 +10242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10498,7 +10498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10754,7 +10754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11010,7 +11010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11266,7 +11266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11522,7 +11522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11778,7 +11778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12034,7 +12034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12290,7 +12290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12546,7 +12546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12802,7 +12802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13058,7 +13058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13314,7 +13314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13570,7 +13570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13826,7 +13826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14082,7 +14082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14338,7 +14338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14594,7 +14594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14850,7 +14850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15106,7 +15106,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15362,7 +15362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15618,7 +15618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_custom.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_custom.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -273,7 +273,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -532,7 +532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -792,7 +792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1053,7 +1053,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1312,7 +1312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1570,7 +1570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1829,7 +1829,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2087,7 +2087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2345,7 +2345,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH.yaml
@@ -52,7 +52,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -437,7 +437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -653,7 +653,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -869,7 +869,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1085,7 +1085,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1301,7 +1301,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1517,7 +1517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1733,7 +1733,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1949,7 +1949,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2165,7 +2165,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2381,7 +2381,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2597,7 +2597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2813,7 +2813,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3029,7 +3029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3245,7 +3245,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3718,7 +3718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3934,7 +3934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4150,7 +4150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4381,7 +4381,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4618,7 +4618,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4855,7 +4855,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5092,7 +5092,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5329,7 +5329,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5566,7 +5566,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5803,7 +5803,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6040,7 +6040,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6282,7 +6282,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6526,7 +6526,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6770,7 +6770,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7014,7 +7014,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7258,7 +7258,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7502,7 +7502,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7741,7 +7741,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7983,7 +7983,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8227,7 +8227,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8471,7 +8471,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_AH_SAV.yaml
@@ -53,7 +53,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -223,7 +223,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -440,7 +440,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -657,7 +657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -874,7 +874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1092,7 +1092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1310,7 +1310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1527,7 +1527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1744,7 +1744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1961,7 +1961,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2178,7 +2178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2395,7 +2395,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2612,7 +2612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2829,7 +2829,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3046,7 +3046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3263,7 +3263,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3482,7 +3482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3701,7 +3701,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3925,7 +3925,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4151,7 +4151,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4373,7 +4373,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4592,7 +4592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4811,7 +4811,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5029,7 +5029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5247,7 +5247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5465,7 +5465,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5683,7 +5683,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5901,7 +5901,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -269,7 +269,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -525,7 +525,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -781,7 +781,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1038,7 +1038,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1295,7 +1295,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1552,7 +1552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1809,7 +1809,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2066,7 +2066,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2323,7 +2323,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2580,7 +2580,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2837,7 +2837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3094,7 +3094,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3351,7 +3351,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3608,7 +3608,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3865,7 +3865,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4122,7 +4122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4379,7 +4379,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Alik_Bljk_F8F8S_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Alik_Bljk_F8F8S_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1298,7 +1298,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1555,7 +1555,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1812,7 +1812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Alik_Bljk_HF8_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Alik_Bljk_HF8_HHS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1298,7 +1298,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1555,7 +1555,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1812,7 +1812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2069,7 +2069,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2326,7 +2326,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/Equality/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -269,7 +269,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -525,7 +525,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -781,7 +781,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1037,7 +1037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1293,7 +1293,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1549,7 +1549,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1805,7 +1805,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2061,7 +2061,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2317,7 +2317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2574,7 +2574,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -269,7 +269,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -526,7 +526,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -783,7 +783,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1040,7 +1040,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1297,7 +1297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1554,7 +1554,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1811,7 +1811,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2068,7 +2068,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2325,7 +2325,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2582,7 +2582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2839,7 +2839,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3096,7 +3096,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3353,7 +3353,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3610,7 +3610,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3867,7 +3867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4124,7 +4124,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4381,7 +4381,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4638,7 +4638,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4895,7 +4895,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5152,7 +5152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5409,7 +5409,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5666,7 +5666,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5923,7 +5923,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6180,7 +6180,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6437,7 +6437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6694,7 +6694,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6951,7 +6951,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7208,7 +7208,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7465,7 +7465,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7722,7 +7722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7979,7 +7979,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8236,7 +8236,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8493,7 +8493,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8750,7 +8750,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9007,7 +9007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9264,7 +9264,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9521,7 +9521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9778,7 +9778,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10035,7 +10035,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10292,7 +10292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10549,7 +10549,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10806,7 +10806,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11063,7 +11063,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11320,7 +11320,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11577,7 +11577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11834,7 +11834,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12091,7 +12091,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12348,7 +12348,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12605,7 +12605,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12862,7 +12862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13119,7 +13119,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13376,7 +13376,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13633,7 +13633,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13890,7 +13890,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14147,7 +14147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14404,7 +14404,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14661,7 +14661,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14918,7 +14918,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15175,7 +15175,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15432,7 +15432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15689,7 +15689,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15946,7 +15946,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16203,7 +16203,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16460,7 +16460,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16717,7 +16717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16974,7 +16974,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17231,7 +17231,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17488,7 +17488,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17745,7 +17745,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18002,7 +18002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18259,7 +18259,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18516,7 +18516,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18773,7 +18773,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19030,7 +19030,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19287,7 +19287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19544,7 +19544,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19801,7 +19801,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20058,7 +20058,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20315,7 +20315,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20572,7 +20572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20829,7 +20829,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21086,7 +21086,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21343,7 +21343,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21600,7 +21600,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21857,7 +21857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22114,7 +22114,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22371,7 +22371,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22628,7 +22628,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22885,7 +22885,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23142,7 +23142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23399,7 +23399,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23656,7 +23656,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23913,7 +23913,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24170,7 +24170,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24427,7 +24427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24684,7 +24684,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24941,7 +24941,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25198,7 +25198,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25455,7 +25455,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25712,7 +25712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25969,7 +25969,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26226,7 +26226,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26483,7 +26483,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26740,7 +26740,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26997,7 +26997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27254,7 +27254,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27511,7 +27511,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27768,7 +27768,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28025,7 +28025,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28282,7 +28282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28539,7 +28539,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28796,7 +28796,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29053,7 +29053,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29310,7 +29310,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29567,7 +29567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29824,7 +29824,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30081,7 +30081,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30338,7 +30338,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30595,7 +30595,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30852,7 +30852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31109,7 +31109,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31366,7 +31366,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31623,7 +31623,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31880,7 +31880,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32137,7 +32137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32394,7 +32394,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32651,7 +32651,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32908,7 +32908,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33165,7 +33165,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33422,7 +33422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33679,7 +33679,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33936,7 +33936,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34193,7 +34193,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34450,7 +34450,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34707,7 +34707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34964,7 +34964,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35221,7 +35221,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35478,7 +35478,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35735,7 +35735,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35992,7 +35992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36249,7 +36249,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36506,7 +36506,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36763,7 +36763,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37020,7 +37020,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37277,7 +37277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37534,7 +37534,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37791,7 +37791,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38048,7 +38048,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38305,7 +38305,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38562,7 +38562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38819,7 +38819,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39076,7 +39076,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39333,7 +39333,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39590,7 +39590,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39847,7 +39847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40104,7 +40104,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40361,7 +40361,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40618,7 +40618,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40875,7 +40875,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41132,7 +41132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41389,7 +41389,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41646,7 +41646,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41903,7 +41903,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42160,7 +42160,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42417,7 +42417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42674,7 +42674,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42931,7 +42931,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43188,7 +43188,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43445,7 +43445,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43702,7 +43702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43959,7 +43959,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44216,7 +44216,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44473,7 +44473,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44730,7 +44730,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44987,7 +44987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45244,7 +45244,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45501,7 +45501,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45758,7 +45758,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46015,7 +46015,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46272,7 +46272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46529,7 +46529,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46786,7 +46786,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47043,7 +47043,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47300,7 +47300,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47557,7 +47557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47814,7 +47814,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48071,7 +48071,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48328,7 +48328,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48585,7 +48585,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48842,7 +48842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49099,7 +49099,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49356,7 +49356,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49613,7 +49613,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49870,7 +49870,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50127,7 +50127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50384,7 +50384,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50641,7 +50641,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50898,7 +50898,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51155,7 +51155,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51412,7 +51412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51669,7 +51669,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51926,7 +51926,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52183,7 +52183,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52440,7 +52440,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52697,7 +52697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52954,7 +52954,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53211,7 +53211,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53468,7 +53468,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53725,7 +53725,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53982,7 +53982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54239,7 +54239,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54496,7 +54496,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54753,7 +54753,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55010,7 +55010,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55267,7 +55267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55524,7 +55524,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55781,7 +55781,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56038,7 +56038,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56295,7 +56295,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56552,7 +56552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56809,7 +56809,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57066,7 +57066,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57323,7 +57323,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57580,7 +57580,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57837,7 +57837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58094,7 +58094,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58351,7 +58351,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58608,7 +58608,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58865,7 +58865,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59122,7 +59122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59379,7 +59379,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59636,7 +59636,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59893,7 +59893,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60150,7 +60150,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60407,7 +60407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60664,7 +60664,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60921,7 +60921,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61178,7 +61178,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61435,7 +61435,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61692,7 +61692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61949,7 +61949,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62206,7 +62206,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62463,7 +62463,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62720,7 +62720,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62977,7 +62977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63234,7 +63234,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63491,7 +63491,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63748,7 +63748,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64005,7 +64005,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64262,7 +64262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64519,7 +64519,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64776,7 +64776,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65033,7 +65033,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65804,7 +65804,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66061,7 +66061,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66318,7 +66318,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66575,7 +66575,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66832,7 +66832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67089,7 +67089,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67346,7 +67346,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67603,7 +67603,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67860,7 +67860,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68117,7 +68117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68374,7 +68374,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68631,7 +68631,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68888,7 +68888,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69145,7 +69145,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69402,7 +69402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69659,7 +69659,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69916,7 +69916,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70173,7 +70173,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70430,7 +70430,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70687,7 +70687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70944,7 +70944,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71201,7 +71201,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71458,7 +71458,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71715,7 +71715,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71972,7 +71972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72229,7 +72229,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72486,7 +72486,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72743,7 +72743,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73000,7 +73000,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73257,7 +73257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73514,7 +73514,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73771,7 +73771,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74028,7 +74028,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74285,7 +74285,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74542,7 +74542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74799,7 +74799,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75056,7 +75056,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75313,7 +75313,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75570,7 +75570,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75827,7 +75827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76084,7 +76084,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76341,7 +76341,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76598,7 +76598,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76855,7 +76855,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77112,7 +77112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77369,7 +77369,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77626,7 +77626,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77883,7 +77883,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78140,7 +78140,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78397,7 +78397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78654,7 +78654,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78911,7 +78911,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79168,7 +79168,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79425,7 +79425,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79682,7 +79682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79939,7 +79939,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80196,7 +80196,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80453,7 +80453,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80710,7 +80710,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80967,7 +80967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81224,7 +81224,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81481,7 +81481,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81738,7 +81738,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81995,7 +81995,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82252,7 +82252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82509,7 +82509,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82766,7 +82766,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83023,7 +83023,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83280,7 +83280,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83537,7 +83537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83794,7 +83794,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84051,7 +84051,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84308,7 +84308,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84565,7 +84565,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84822,7 +84822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85079,7 +85079,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85336,7 +85336,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85593,7 +85593,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85850,7 +85850,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86107,7 +86107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86364,7 +86364,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86621,7 +86621,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86878,7 +86878,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87135,7 +87135,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87392,7 +87392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87649,7 +87649,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87906,7 +87906,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88163,7 +88163,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88420,7 +88420,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88677,7 +88677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88934,7 +88934,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89191,7 +89191,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89448,7 +89448,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89705,7 +89705,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89962,7 +89962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90219,7 +90219,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90476,7 +90476,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90733,7 +90733,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90990,7 +90990,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91247,7 +91247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91504,7 +91504,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91761,7 +91761,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92018,7 +92018,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92275,7 +92275,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92532,7 +92532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92789,7 +92789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93046,7 +93046,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93303,7 +93303,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93560,7 +93560,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93817,7 +93817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94074,7 +94074,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94331,7 +94331,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94588,7 +94588,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94845,7 +94845,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95102,7 +95102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95359,7 +95359,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95616,7 +95616,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95873,7 +95873,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96130,7 +96130,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96387,7 +96387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96644,7 +96644,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96901,7 +96901,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97158,7 +97158,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97415,7 +97415,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97672,7 +97672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97929,7 +97929,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98186,7 +98186,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98443,7 +98443,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98700,7 +98700,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98957,7 +98957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99214,7 +99214,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99471,7 +99471,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99728,7 +99728,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99985,7 +99985,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100242,7 +100242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100499,7 +100499,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100756,7 +100756,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101013,7 +101013,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101270,7 +101270,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101527,7 +101527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101784,7 +101784,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102041,7 +102041,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102298,7 +102298,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102555,7 +102555,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102812,7 +102812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103069,7 +103069,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103326,7 +103326,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103583,7 +103583,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103840,7 +103840,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104097,7 +104097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104354,7 +104354,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104611,7 +104611,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104868,7 +104868,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105125,7 +105125,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105382,7 +105382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105639,7 +105639,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105896,7 +105896,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106153,7 +106153,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106410,7 +106410,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106667,7 +106667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106924,7 +106924,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107181,7 +107181,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107438,7 +107438,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107695,7 +107695,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107952,7 +107952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108209,7 +108209,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108466,7 +108466,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108723,7 +108723,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108980,7 +108980,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109237,7 +109237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109494,7 +109494,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109751,7 +109751,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110008,7 +110008,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110265,7 +110265,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110522,7 +110522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110779,7 +110779,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111036,7 +111036,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111293,7 +111293,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111550,7 +111550,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111807,7 +111807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112064,7 +112064,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112321,7 +112321,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112578,7 +112578,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112835,7 +112835,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113092,7 +113092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113349,7 +113349,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113606,7 +113606,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113863,7 +113863,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114120,7 +114120,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114377,7 +114377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114634,7 +114634,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114891,7 +114891,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115148,7 +115148,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115405,7 +115405,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115662,7 +115662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115919,7 +115919,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116176,7 +116176,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116433,7 +116433,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116690,7 +116690,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116947,7 +116947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117204,7 +117204,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117461,7 +117461,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117718,7 +117718,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117975,7 +117975,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118232,7 +118232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118489,7 +118489,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118746,7 +118746,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119003,7 +119003,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119260,7 +119260,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119517,7 +119517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119774,7 +119774,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120031,7 +120031,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120288,7 +120288,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120545,7 +120545,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120802,7 +120802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121059,7 +121059,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121316,7 +121316,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121573,7 +121573,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121830,7 +121830,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122087,7 +122087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122344,7 +122344,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122601,7 +122601,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122858,7 +122858,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123115,7 +123115,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123372,7 +123372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123629,7 +123629,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123886,7 +123886,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124143,7 +124143,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124400,7 +124400,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124657,7 +124657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124914,7 +124914,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125171,7 +125171,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125428,7 +125428,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125685,7 +125685,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125942,7 +125942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126199,7 +126199,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126456,7 +126456,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126713,7 +126713,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126970,7 +126970,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127227,7 +127227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127484,7 +127484,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127741,7 +127741,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127998,7 +127998,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -128255,7 +128255,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -128512,7 +128512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -128769,7 +128769,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129026,7 +129026,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129283,7 +129283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129540,7 +129540,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129797,7 +129797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130054,7 +130054,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130311,7 +130311,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130568,7 +130568,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130825,7 +130825,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131082,7 +131082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131339,7 +131339,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131596,7 +131596,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131853,7 +131853,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132110,7 +132110,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132367,7 +132367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132624,7 +132624,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132881,7 +132881,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133138,7 +133138,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133395,7 +133395,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133652,7 +133652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133909,7 +133909,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134166,7 +134166,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134423,7 +134423,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134680,7 +134680,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134937,7 +134937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135194,7 +135194,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135451,7 +135451,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135708,7 +135708,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135965,7 +135965,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136222,7 +136222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136479,7 +136479,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136736,7 +136736,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136993,7 +136993,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -137250,7 +137250,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -137507,7 +137507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -137764,7 +137764,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138021,7 +138021,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138278,7 +138278,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138535,7 +138535,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138792,7 +138792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139049,7 +139049,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139306,7 +139306,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139563,7 +139563,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139820,7 +139820,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -140077,7 +140077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -140334,7 +140334,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -140591,7 +140591,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -140848,7 +140848,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -141105,7 +141105,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117570,7 +117570,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117828,7 +117828,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118086,7 +118086,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118344,7 +118344,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118602,7 +118602,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118860,7 +118860,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119118,7 +119118,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119376,7 +119376,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119634,7 +119634,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119892,7 +119892,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120150,7 +120150,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120408,7 +120408,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120663,7 +120663,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120918,7 +120918,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121173,7 +121173,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121428,7 +121428,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121686,7 +121686,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121944,7 +121944,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122202,7 +122202,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122460,7 +122460,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122718,7 +122718,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_GG_SAB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_GG_SAB_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117109,7 +117109,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117366,7 +117366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117623,7 +117623,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117570,7 +117570,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117828,7 +117828,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118086,7 +118086,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118344,7 +118344,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118602,7 +118602,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118860,7 +118860,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119118,7 +119118,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119376,7 +119376,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119634,7 +119634,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119892,7 +119892,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120150,7 +120150,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120408,7 +120408,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120663,7 +120663,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120918,7 +120918,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121173,7 +121173,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121428,7 +121428,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121686,7 +121686,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121944,7 +121944,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122202,7 +122202,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122460,7 +122460,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122718,7 +122718,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_GG_SAB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_GG_SAB_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_GG_SAB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_GG_SAB_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_GG_SAB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_GG_SAB_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_SAB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_SAB_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1537,7 +1537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1791,7 +1791,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2045,7 +2045,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2299,7 +2299,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2553,7 +2553,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2807,7 +2807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3061,7 +3061,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3315,7 +3315,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3569,7 +3569,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3823,7 +3823,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4077,7 +4077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4331,7 +4331,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4585,7 +4585,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4839,7 +4839,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5093,7 +5093,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5347,7 +5347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5601,7 +5601,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5855,7 +5855,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6109,7 +6109,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6363,7 +6363,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6617,7 +6617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6871,7 +6871,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7125,7 +7125,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7379,7 +7379,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7633,7 +7633,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7887,7 +7887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8141,7 +8141,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8395,7 +8395,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8649,7 +8649,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8903,7 +8903,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9157,7 +9157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9411,7 +9411,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9665,7 +9665,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9919,7 +9919,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10173,7 +10173,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10427,7 +10427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10681,7 +10681,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10935,7 +10935,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11189,7 +11189,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11443,7 +11443,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11697,7 +11697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11951,7 +11951,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12205,7 +12205,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12459,7 +12459,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12713,7 +12713,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12967,7 +12967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13221,7 +13221,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13475,7 +13475,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13729,7 +13729,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13983,7 +13983,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14237,7 +14237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14491,7 +14491,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14745,7 +14745,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14999,7 +14999,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15253,7 +15253,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15507,7 +15507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15761,7 +15761,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16015,7 +16015,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16269,7 +16269,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16523,7 +16523,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16777,7 +16777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17031,7 +17031,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17285,7 +17285,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17539,7 +17539,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17793,7 +17793,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18047,7 +18047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18301,7 +18301,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18555,7 +18555,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18809,7 +18809,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19063,7 +19063,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19317,7 +19317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19571,7 +19571,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19825,7 +19825,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20079,7 +20079,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20333,7 +20333,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20587,7 +20587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20841,7 +20841,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21095,7 +21095,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21349,7 +21349,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21603,7 +21603,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21857,7 +21857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22111,7 +22111,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22365,7 +22365,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22619,7 +22619,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22873,7 +22873,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23127,7 +23127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23381,7 +23381,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23635,7 +23635,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23889,7 +23889,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24143,7 +24143,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24397,7 +24397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24651,7 +24651,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24905,7 +24905,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25159,7 +25159,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25413,7 +25413,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25667,7 +25667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25921,7 +25921,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26175,7 +26175,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26429,7 +26429,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26683,7 +26683,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26937,7 +26937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27191,7 +27191,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27445,7 +27445,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27699,7 +27699,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27953,7 +27953,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28207,7 +28207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28461,7 +28461,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28715,7 +28715,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28969,7 +28969,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29223,7 +29223,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29477,7 +29477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29731,7 +29731,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29985,7 +29985,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30239,7 +30239,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30493,7 +30493,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30747,7 +30747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31001,7 +31001,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31255,7 +31255,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31509,7 +31509,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31763,7 +31763,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32017,7 +32017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32271,7 +32271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32525,7 +32525,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32779,7 +32779,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33033,7 +33033,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33287,7 +33287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33541,7 +33541,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33795,7 +33795,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34049,7 +34049,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34303,7 +34303,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34557,7 +34557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34811,7 +34811,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35065,7 +35065,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35319,7 +35319,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35573,7 +35573,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35827,7 +35827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36081,7 +36081,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36335,7 +36335,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36589,7 +36589,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36843,7 +36843,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37097,7 +37097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37351,7 +37351,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37605,7 +37605,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37859,7 +37859,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38113,7 +38113,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38367,7 +38367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38621,7 +38621,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38875,7 +38875,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39129,7 +39129,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39383,7 +39383,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39637,7 +39637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39891,7 +39891,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40145,7 +40145,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40399,7 +40399,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40653,7 +40653,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40907,7 +40907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41161,7 +41161,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41415,7 +41415,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41669,7 +41669,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41923,7 +41923,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117570,7 +117570,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117827,7 +117827,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118084,7 +118084,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118341,7 +118341,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118598,7 +118598,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118855,7 +118855,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119112,7 +119112,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119369,7 +119369,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119623,7 +119623,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119877,7 +119877,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120131,7 +120131,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120385,7 +120385,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120642,7 +120642,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120899,7 +120899,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121156,7 +121156,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121413,7 +121413,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121670,7 +121670,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121927,7 +121927,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122184,7 +122184,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_GG_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_GG_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117570,7 +117570,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117827,7 +117827,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118084,7 +118084,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118341,7 +118341,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118598,7 +118598,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118855,7 +118855,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119112,7 +119112,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119369,7 +119369,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119623,7 +119623,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119877,7 +119877,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120131,7 +120131,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120385,7 +120385,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120642,7 +120642,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120899,7 +120899,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121156,7 +121156,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121413,7 +121413,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121670,7 +121670,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121927,7 +121927,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122184,7 +122184,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_GG_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_GG_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_Bias_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_Bias_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1537,7 +1537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1791,7 +1791,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2045,7 +2045,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2299,7 +2299,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2553,7 +2553,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2807,7 +2807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3061,7 +3061,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3315,7 +3315,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3569,7 +3569,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3823,7 +3823,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4077,7 +4077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4331,7 +4331,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4585,7 +4585,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4839,7 +4839,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5093,7 +5093,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5347,7 +5347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5601,7 +5601,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5855,7 +5855,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6109,7 +6109,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6363,7 +6363,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6617,7 +6617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6871,7 +6871,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7125,7 +7125,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7379,7 +7379,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7633,7 +7633,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7887,7 +7887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8141,7 +8141,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8395,7 +8395,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8649,7 +8649,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8903,7 +8903,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9157,7 +9157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9411,7 +9411,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9665,7 +9665,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9919,7 +9919,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10173,7 +10173,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10427,7 +10427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10681,7 +10681,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10935,7 +10935,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11189,7 +11189,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11443,7 +11443,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11697,7 +11697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11951,7 +11951,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12205,7 +12205,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12459,7 +12459,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12713,7 +12713,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12967,7 +12967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13221,7 +13221,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13475,7 +13475,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13729,7 +13729,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13983,7 +13983,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14237,7 +14237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14491,7 +14491,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14745,7 +14745,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14999,7 +14999,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15253,7 +15253,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15507,7 +15507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15761,7 +15761,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16015,7 +16015,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16269,7 +16269,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16523,7 +16523,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16777,7 +16777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17031,7 +17031,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17285,7 +17285,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17539,7 +17539,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17793,7 +17793,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18047,7 +18047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18301,7 +18301,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18555,7 +18555,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18809,7 +18809,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19063,7 +19063,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19317,7 +19317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19571,7 +19571,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19825,7 +19825,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20079,7 +20079,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20333,7 +20333,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20587,7 +20587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20841,7 +20841,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21095,7 +21095,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21349,7 +21349,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21603,7 +21603,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21857,7 +21857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22111,7 +22111,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22365,7 +22365,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22619,7 +22619,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22873,7 +22873,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23127,7 +23127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23381,7 +23381,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23635,7 +23635,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23889,7 +23889,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24143,7 +24143,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24397,7 +24397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24651,7 +24651,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24905,7 +24905,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25159,7 +25159,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25413,7 +25413,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25667,7 +25667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25921,7 +25921,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26175,7 +26175,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26429,7 +26429,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26683,7 +26683,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26937,7 +26937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27191,7 +27191,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27445,7 +27445,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27699,7 +27699,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27953,7 +27953,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28207,7 +28207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28461,7 +28461,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28715,7 +28715,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28969,7 +28969,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29223,7 +29223,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29477,7 +29477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29731,7 +29731,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29985,7 +29985,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30239,7 +30239,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30493,7 +30493,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30747,7 +30747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31001,7 +31001,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31255,7 +31255,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31509,7 +31509,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31763,7 +31763,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32017,7 +32017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32271,7 +32271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32525,7 +32525,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32779,7 +32779,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33033,7 +33033,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33287,7 +33287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33541,7 +33541,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33795,7 +33795,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34049,7 +34049,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34303,7 +34303,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34557,7 +34557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34811,7 +34811,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35065,7 +35065,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35319,7 +35319,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35573,7 +35573,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35827,7 +35827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36081,7 +36081,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36335,7 +36335,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36589,7 +36589,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36843,7 +36843,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37097,7 +37097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37351,7 +37351,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37605,7 +37605,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37859,7 +37859,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38113,7 +38113,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38367,7 +38367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38621,7 +38621,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38875,7 +38875,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39129,7 +39129,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39383,7 +39383,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39637,7 +39637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39891,7 +39891,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40145,7 +40145,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40399,7 +40399,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40653,7 +40653,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40907,7 +40907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41161,7 +41161,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41415,7 +41415,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41669,7 +41669,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41923,7 +41923,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42177,7 +42177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42431,7 +42431,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42685,7 +42685,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42939,7 +42939,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43193,7 +43193,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43447,7 +43447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43701,7 +43701,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43955,7 +43955,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44209,7 +44209,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44463,7 +44463,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44717,7 +44717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44971,7 +44971,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45225,7 +45225,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45479,7 +45479,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45733,7 +45733,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45987,7 +45987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46244,7 +46244,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -259,7 +259,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -507,7 +507,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -687,7 +687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -681,7 +681,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_I8II_BH_AI_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_I8II_BH_AI_SAV_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -264,7 +264,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -516,7 +516,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -768,7 +768,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1020,7 +1020,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1272,7 +1272,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_Aux_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_Aux_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_S_MX_B_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_S_MX_B_Bias_A_SAV.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -256,7 +256,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -506,7 +506,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -755,7 +755,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1005,7 +1005,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_BiasSrcD_GradB_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_BiasSrcD_GradB_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_DB_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -259,7 +259,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -507,7 +507,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1537,7 +1537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1537,7 +1537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1537,7 +1537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1537,7 +1537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1791,7 +1791,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2045,7 +2045,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2299,7 +2299,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2553,7 +2553,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2807,7 +2807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3061,7 +3061,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3315,7 +3315,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3569,7 +3569,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3823,7 +3823,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4077,7 +4077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4331,7 +4331,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4585,7 +4585,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4839,7 +4839,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5093,7 +5093,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5347,7 +5347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5601,7 +5601,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5855,7 +5855,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6109,7 +6109,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6363,7 +6363,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6617,7 +6617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6871,7 +6871,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7125,7 +7125,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7379,7 +7379,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7633,7 +7633,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7887,7 +7887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8141,7 +8141,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8395,7 +8395,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8649,7 +8649,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8903,7 +8903,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9157,7 +9157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9411,7 +9411,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9665,7 +9665,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9919,7 +9919,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10173,7 +10173,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10427,7 +10427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10681,7 +10681,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10935,7 +10935,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11189,7 +11189,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11443,7 +11443,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11697,7 +11697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11951,7 +11951,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12205,7 +12205,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12459,7 +12459,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12713,7 +12713,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12967,7 +12967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13221,7 +13221,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13475,7 +13475,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13729,7 +13729,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13983,7 +13983,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14237,7 +14237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14491,7 +14491,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14745,7 +14745,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14999,7 +14999,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15253,7 +15253,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15507,7 +15507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15761,7 +15761,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16015,7 +16015,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16269,7 +16269,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16523,7 +16523,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16777,7 +16777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17031,7 +17031,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17285,7 +17285,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17539,7 +17539,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17793,7 +17793,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18047,7 +18047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18301,7 +18301,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18555,7 +18555,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18809,7 +18809,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19063,7 +19063,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19317,7 +19317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19571,7 +19571,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19825,7 +19825,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20079,7 +20079,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20333,7 +20333,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20587,7 +20587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20841,7 +20841,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21095,7 +21095,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21349,7 +21349,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21603,7 +21603,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21857,7 +21857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22111,7 +22111,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22365,7 +22365,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22619,7 +22619,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22873,7 +22873,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23127,7 +23127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23381,7 +23381,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23635,7 +23635,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23889,7 +23889,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24143,7 +24143,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24397,7 +24397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24651,7 +24651,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24905,7 +24905,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25159,7 +25159,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25413,7 +25413,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25667,7 +25667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25921,7 +25921,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26175,7 +26175,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26429,7 +26429,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26683,7 +26683,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26937,7 +26937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27191,7 +27191,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27445,7 +27445,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27699,7 +27699,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27953,7 +27953,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28207,7 +28207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28461,7 +28461,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28715,7 +28715,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28969,7 +28969,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29223,7 +29223,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29477,7 +29477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29731,7 +29731,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29985,7 +29985,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30239,7 +30239,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30493,7 +30493,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30747,7 +30747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31001,7 +31001,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31255,7 +31255,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31509,7 +31509,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31763,7 +31763,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32017,7 +32017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32271,7 +32271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32525,7 +32525,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32779,7 +32779,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33033,7 +33033,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33287,7 +33287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33541,7 +33541,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33795,7 +33795,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34049,7 +34049,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34303,7 +34303,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34557,7 +34557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34811,7 +34811,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35065,7 +35065,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35319,7 +35319,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35573,7 +35573,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35827,7 +35827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36081,7 +36081,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36335,7 +36335,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36589,7 +36589,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36843,7 +36843,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37097,7 +37097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37351,7 +37351,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37605,7 +37605,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37859,7 +37859,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38113,7 +38113,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38367,7 +38367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38621,7 +38621,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38875,7 +38875,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39129,7 +39129,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39383,7 +39383,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39637,7 +39637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39891,7 +39891,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40145,7 +40145,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40399,7 +40399,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40653,7 +40653,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40907,7 +40907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41161,7 +41161,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41415,7 +41415,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41669,7 +41669,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41923,7 +41923,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42177,7 +42177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42431,7 +42431,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42685,7 +42685,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42939,7 +42939,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43193,7 +43193,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43447,7 +43447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43701,7 +43701,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43955,7 +43955,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44209,7 +44209,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44463,7 +44463,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44717,7 +44717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44971,7 +44971,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45225,7 +45225,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45479,7 +45479,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45733,7 +45733,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45987,7 +45987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46241,7 +46241,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46495,7 +46495,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46749,7 +46749,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47003,7 +47003,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47257,7 +47257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47511,7 +47511,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47765,7 +47765,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48019,7 +48019,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48273,7 +48273,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48527,7 +48527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48781,7 +48781,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49035,7 +49035,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49289,7 +49289,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49543,7 +49543,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49797,7 +49797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50051,7 +50051,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50305,7 +50305,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50559,7 +50559,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50813,7 +50813,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51067,7 +51067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51321,7 +51321,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51575,7 +51575,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51829,7 +51829,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52083,7 +52083,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52337,7 +52337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52591,7 +52591,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52845,7 +52845,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53099,7 +53099,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53353,7 +53353,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53607,7 +53607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53861,7 +53861,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54115,7 +54115,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54369,7 +54369,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54623,7 +54623,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54877,7 +54877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55131,7 +55131,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55385,7 +55385,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55639,7 +55639,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55893,7 +55893,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56147,7 +56147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56401,7 +56401,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56655,7 +56655,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56909,7 +56909,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57163,7 +57163,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57417,7 +57417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57671,7 +57671,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57925,7 +57925,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58179,7 +58179,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58433,7 +58433,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58687,7 +58687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58941,7 +58941,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59195,7 +59195,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59449,7 +59449,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59703,7 +59703,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59957,7 +59957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60211,7 +60211,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60465,7 +60465,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60719,7 +60719,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60973,7 +60973,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61227,7 +61227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61481,7 +61481,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61735,7 +61735,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61989,7 +61989,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62243,7 +62243,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62497,7 +62497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62751,7 +62751,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63005,7 +63005,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63259,7 +63259,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63513,7 +63513,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63767,7 +63767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64021,7 +64021,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64275,7 +64275,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64529,7 +64529,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64783,7 +64783,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65291,7 +65291,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65545,7 +65545,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65799,7 +65799,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66053,7 +66053,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66307,7 +66307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66561,7 +66561,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66815,7 +66815,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67069,7 +67069,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67323,7 +67323,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67577,7 +67577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67831,7 +67831,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68085,7 +68085,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68339,7 +68339,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68593,7 +68593,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68847,7 +68847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69101,7 +69101,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69355,7 +69355,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69609,7 +69609,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69863,7 +69863,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70117,7 +70117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70371,7 +70371,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70625,7 +70625,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70879,7 +70879,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71133,7 +71133,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71387,7 +71387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71641,7 +71641,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71895,7 +71895,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72149,7 +72149,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72403,7 +72403,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72657,7 +72657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72911,7 +72911,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73165,7 +73165,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73419,7 +73419,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73673,7 +73673,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73927,7 +73927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74181,7 +74181,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74435,7 +74435,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74689,7 +74689,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74943,7 +74943,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75197,7 +75197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75451,7 +75451,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75705,7 +75705,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75959,7 +75959,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76213,7 +76213,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76467,7 +76467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76721,7 +76721,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76975,7 +76975,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77229,7 +77229,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77483,7 +77483,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77737,7 +77737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77991,7 +77991,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78245,7 +78245,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78499,7 +78499,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78753,7 +78753,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79007,7 +79007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79261,7 +79261,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79515,7 +79515,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79769,7 +79769,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80023,7 +80023,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80277,7 +80277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80531,7 +80531,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80785,7 +80785,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81039,7 +81039,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81293,7 +81293,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81547,7 +81547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81801,7 +81801,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82055,7 +82055,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82309,7 +82309,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82563,7 +82563,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82817,7 +82817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83071,7 +83071,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83325,7 +83325,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83579,7 +83579,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83833,7 +83833,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84087,7 +84087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84341,7 +84341,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84595,7 +84595,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84849,7 +84849,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85103,7 +85103,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85357,7 +85357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85611,7 +85611,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85865,7 +85865,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86119,7 +86119,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86373,7 +86373,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86627,7 +86627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86881,7 +86881,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87135,7 +87135,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87389,7 +87389,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87643,7 +87643,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87897,7 +87897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88151,7 +88151,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88405,7 +88405,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88659,7 +88659,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88913,7 +88913,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89167,7 +89167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89421,7 +89421,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89675,7 +89675,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89929,7 +89929,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90183,7 +90183,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90437,7 +90437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90691,7 +90691,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90945,7 +90945,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91199,7 +91199,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91453,7 +91453,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91707,7 +91707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91961,7 +91961,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92215,7 +92215,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92469,7 +92469,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92723,7 +92723,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92977,7 +92977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93231,7 +93231,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93485,7 +93485,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93739,7 +93739,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93993,7 +93993,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94247,7 +94247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94501,7 +94501,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94755,7 +94755,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95009,7 +95009,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95263,7 +95263,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95517,7 +95517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95771,7 +95771,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96025,7 +96025,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96279,7 +96279,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96533,7 +96533,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96787,7 +96787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97041,7 +97041,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97295,7 +97295,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97549,7 +97549,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97803,7 +97803,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98057,7 +98057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98311,7 +98311,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98565,7 +98565,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98819,7 +98819,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99073,7 +99073,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99327,7 +99327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99581,7 +99581,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99835,7 +99835,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100089,7 +100089,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100343,7 +100343,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100597,7 +100597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100851,7 +100851,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101105,7 +101105,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101359,7 +101359,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101613,7 +101613,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101867,7 +101867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102121,7 +102121,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102375,7 +102375,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102629,7 +102629,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102883,7 +102883,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103137,7 +103137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103391,7 +103391,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103645,7 +103645,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103899,7 +103899,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104153,7 +104153,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104407,7 +104407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104661,7 +104661,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104915,7 +104915,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105169,7 +105169,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105423,7 +105423,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105677,7 +105677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105931,7 +105931,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106185,7 +106185,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106439,7 +106439,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106693,7 +106693,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106947,7 +106947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107201,7 +107201,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107455,7 +107455,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107709,7 +107709,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107963,7 +107963,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108217,7 +108217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108471,7 +108471,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108725,7 +108725,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108979,7 +108979,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109233,7 +109233,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109487,7 +109487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109741,7 +109741,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109995,7 +109995,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110249,7 +110249,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110503,7 +110503,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110757,7 +110757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111011,7 +111011,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111265,7 +111265,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111519,7 +111519,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111773,7 +111773,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112027,7 +112027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112281,7 +112281,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112535,7 +112535,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112789,7 +112789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113043,7 +113043,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113297,7 +113297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113551,7 +113551,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113805,7 +113805,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114059,7 +114059,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114313,7 +114313,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114567,7 +114567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114821,7 +114821,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115075,7 +115075,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115329,7 +115329,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115583,7 +115583,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115837,7 +115837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116091,7 +116091,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116345,7 +116345,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116599,7 +116599,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116853,7 +116853,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117107,7 +117107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117361,7 +117361,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117615,7 +117615,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117869,7 +117869,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118123,7 +118123,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118377,7 +118377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118631,7 +118631,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118885,7 +118885,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119139,7 +119139,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119393,7 +119393,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119647,7 +119647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119901,7 +119901,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120155,7 +120155,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120409,7 +120409,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120663,7 +120663,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120917,7 +120917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121171,7 +121171,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121425,7 +121425,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121679,7 +121679,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121933,7 +121933,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122187,7 +122187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122441,7 +122441,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122695,7 +122695,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122949,7 +122949,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123203,7 +123203,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123457,7 +123457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123711,7 +123711,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123965,7 +123965,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124219,7 +124219,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124473,7 +124473,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124727,7 +124727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124981,7 +124981,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125235,7 +125235,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125489,7 +125489,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125743,7 +125743,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125997,7 +125997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126251,7 +126251,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126505,7 +126505,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126759,7 +126759,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127013,7 +127013,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127267,7 +127267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127521,7 +127521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127775,7 +127775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -128029,7 +128029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -128283,7 +128283,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -128537,7 +128537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -128791,7 +128791,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129045,7 +129045,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129299,7 +129299,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129553,7 +129553,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129807,7 +129807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130061,7 +130061,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130315,7 +130315,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130569,7 +130569,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130823,7 +130823,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131077,7 +131077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131331,7 +131331,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131585,7 +131585,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131839,7 +131839,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132093,7 +132093,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132347,7 +132347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132601,7 +132601,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132855,7 +132855,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133109,7 +133109,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133363,7 +133363,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133617,7 +133617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133871,7 +133871,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134125,7 +134125,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134379,7 +134379,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134633,7 +134633,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134887,7 +134887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135141,7 +135141,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135395,7 +135395,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135649,7 +135649,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135903,7 +135903,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136157,7 +136157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136411,7 +136411,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136665,7 +136665,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136919,7 +136919,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -137173,7 +137173,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -137427,7 +137427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -137681,7 +137681,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -137935,7 +137935,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138189,7 +138189,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138443,7 +138443,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138697,7 +138697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138951,7 +138951,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139205,7 +139205,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139459,7 +139459,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139713,7 +139713,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -687,7 +687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -681,7 +681,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -681,7 +681,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_I8II_BH_AI_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_I8II_BH_AI_SAV_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -264,7 +264,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -516,7 +516,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -768,7 +768,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1020,7 +1020,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1272,7 +1272,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_Aux_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_Aux_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_A_SAV.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -256,7 +256,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -505,7 +505,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -754,7 +754,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1004,7 +1004,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_BBS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_BBS_BH_Bias_AH_SAV.yaml
@@ -52,7 +52,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_DB_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -259,7 +259,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -507,7 +507,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HHS_BH_Bias_AS_SAB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HHS_BH_Bias_AS_SAB_SAV.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HSS_BH_Bias_AS_SAB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HSS_BH_Bias_AS_SAB_SAV.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_AH_SAV.yaml
@@ -52,7 +52,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -687,7 +687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -681,7 +681,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_AH_SAV.yaml
@@ -52,7 +52,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_I8II_BH_AI_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_I8II_BH_AI_SAV_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: true
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -264,7 +264,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -516,7 +516,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -768,7 +768,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1020,7 +1020,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_A_SAV.yaml
@@ -52,7 +52,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_Aux_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_Aux_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_S_MX_B_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bjlk_S_MX_B_Bias_A_SAV.yaml
@@ -62,7 +62,7 @@
   TransposeA: true
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -256,7 +256,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -506,7 +506,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -755,7 +755,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1566,7 +1566,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_DB_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -259,7 +259,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -507,7 +507,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8BS_BH_BiasB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8BS_BH_BiasB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1298,7 +1298,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1555,7 +1555,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8BS_BH_BiasB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8BS_BH_BiasB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -687,7 +687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -682,7 +682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -264,7 +264,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -516,7 +516,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -768,7 +768,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1020,7 +1020,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_I8II_BH_AI_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_I8II_BH_AI_SAV_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -264,7 +264,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -516,7 +516,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -768,7 +768,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1020,7 +1020,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1272,7 +1272,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_Aux_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_Aux_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_S_MX_B_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx941/GridBased/aquavanjaram_Cijk_Alik_Bljk_S_MX_B_Bias_A_SAV.yaml
@@ -62,7 +62,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -256,7 +256,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -506,7 +506,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -755,7 +755,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1005,7 +1005,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -269,7 +269,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -525,7 +525,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -781,7 +781,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1037,7 +1037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1294,7 +1294,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1551,7 +1551,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1808,7 +1808,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2065,7 +2065,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2322,7 +2322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2579,7 +2579,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_F8BS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_F8BS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1566,7 +1566,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1825,7 +1825,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_F8F8S_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_F8F8S_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1298,7 +1298,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1555,7 +1555,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1812,7 +1812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_F8HS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_F8HS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1566,7 +1566,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1825,7 +1825,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -269,7 +269,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -525,7 +525,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -781,7 +781,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1037,7 +1037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_SB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_SB_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1566,7 +1566,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1825,7 +1825,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -269,7 +269,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -525,7 +525,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -781,7 +781,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1038,7 +1038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1295,7 +1295,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1552,7 +1552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1809,7 +1809,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2066,7 +2066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8BS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8BS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1566,7 +1566,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8F8S_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8F8S_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1298,7 +1298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1555,7 +1555,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1812,7 +1812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8HS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8HS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1566,7 +1566,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1825,7 +1825,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -54,7 +54,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -228,7 +228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -449,7 +449,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -670,7 +670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -891,7 +891,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1112,7 +1112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1333,7 +1333,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1554,7 +1554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1775,7 +1775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1996,7 +1996,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2217,7 +2217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2438,7 +2438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2659,7 +2659,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2880,7 +2880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3101,7 +3101,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3322,7 +3322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3581,7 +3581,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3810,7 +3810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4031,7 +4031,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4252,7 +4252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4488,7 +4488,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4730,7 +4730,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4972,7 +4972,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5214,7 +5214,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5456,7 +5456,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5698,7 +5698,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5940,7 +5940,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6182,7 +6182,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6429,7 +6429,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6677,7 +6677,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6925,7 +6925,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7173,7 +7173,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7421,7 +7421,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7669,7 +7669,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7912,7 +7912,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8159,7 +8159,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8407,7 +8407,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8655,7 +8655,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8913,7 +8913,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9170,7 +9170,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9427,7 +9427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9684,7 +9684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9941,7 +9941,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10198,7 +10198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10455,7 +10455,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10712,7 +10712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10969,7 +10969,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11226,7 +11226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11483,7 +11483,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11741,7 +11741,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11998,7 +11998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12255,7 +12255,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12512,7 +12512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12770,7 +12770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13028,7 +13028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_custom.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_custom.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -528,7 +528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -786,7 +786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1044,7 +1044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1302,7 +1302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1560,7 +1560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1818,7 +1818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2076,7 +2076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2334,7 +2334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2592,7 +2592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2850,7 +2850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3108,7 +3108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3366,7 +3366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3624,7 +3624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3882,7 +3882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_UserArgs.yaml
@@ -54,7 +54,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -225,7 +225,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -443,7 +443,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -661,7 +661,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -879,7 +879,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1097,7 +1097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1315,7 +1315,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1533,7 +1533,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1751,7 +1751,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1969,7 +1969,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2187,7 +2187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2405,7 +2405,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2623,7 +2623,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2841,7 +2841,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3059,7 +3059,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3277,7 +3277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3754,7 +3754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3972,7 +3972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4190,7 +4190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4423,7 +4423,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4662,7 +4662,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4901,7 +4901,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5140,7 +5140,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5379,7 +5379,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5618,7 +5618,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5857,7 +5857,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6096,7 +6096,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6340,7 +6340,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6586,7 +6586,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6832,7 +6832,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7078,7 +7078,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7324,7 +7324,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7570,7 +7570,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7811,7 +7811,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8055,7 +8055,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8301,7 +8301,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8547,7 +8547,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8796,7 +8796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9053,7 +9053,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9310,7 +9310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9567,7 +9567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9824,7 +9824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10081,7 +10081,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10338,7 +10338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10595,7 +10595,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10852,7 +10852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11109,7 +11109,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11366,7 +11366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11623,7 +11623,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11881,7 +11881,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12138,7 +12138,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12395,7 +12395,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12652,7 +12652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_custom.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_custom.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -528,7 +528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -786,7 +786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1044,7 +1044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1302,7 +1302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1560,7 +1560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1818,7 +1818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2076,7 +2076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2334,7 +2334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2592,7 +2592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2850,7 +2850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3108,7 +3108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3366,7 +3366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3624,7 +3624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3882,7 +3882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -54,7 +54,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -228,7 +228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -449,7 +449,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -670,7 +670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -891,7 +891,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1112,7 +1112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1333,7 +1333,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1554,7 +1554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1775,7 +1775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1996,7 +1996,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2217,7 +2217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2438,7 +2438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2659,7 +2659,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2880,7 +2880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3101,7 +3101,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3322,7 +3322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3581,7 +3581,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3810,7 +3810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4031,7 +4031,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4252,7 +4252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4488,7 +4488,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4730,7 +4730,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4972,7 +4972,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5214,7 +5214,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5456,7 +5456,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5698,7 +5698,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5940,7 +5940,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6182,7 +6182,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6429,7 +6429,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6677,7 +6677,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6925,7 +6925,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7173,7 +7173,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7421,7 +7421,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7669,7 +7669,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7912,7 +7912,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8159,7 +8159,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8407,7 +8407,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8655,7 +8655,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8906,7 +8906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9406,7 +9406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9656,7 +9656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9906,7 +9906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10156,7 +10156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10406,7 +10406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10656,7 +10656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10906,7 +10906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11156,7 +11156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11408,7 +11408,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11660,7 +11660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11912,7 +11912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12164,7 +12164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12416,7 +12416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12668,7 +12668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12920,7 +12920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13172,7 +13172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13424,7 +13424,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13676,7 +13676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13929,7 +13929,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14182,7 +14182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14435,7 +14435,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14688,7 +14688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14941,7 +14941,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15194,7 +15194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15447,7 +15447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_UserArgs.yaml
@@ -54,7 +54,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -225,7 +225,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -443,7 +443,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -661,7 +661,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -879,7 +879,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1097,7 +1097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1315,7 +1315,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1533,7 +1533,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1751,7 +1751,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1969,7 +1969,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2187,7 +2187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2405,7 +2405,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2623,7 +2623,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2841,7 +2841,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3059,7 +3059,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3277,7 +3277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3754,7 +3754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3972,7 +3972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4190,7 +4190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4423,7 +4423,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4662,7 +4662,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4901,7 +4901,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5140,7 +5140,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5379,7 +5379,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5618,7 +5618,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5857,7 +5857,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6096,7 +6096,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6340,7 +6340,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6586,7 +6586,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6832,7 +6832,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7078,7 +7078,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7324,7 +7324,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7570,7 +7570,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7811,7 +7811,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -8055,7 +8055,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8301,7 +8301,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8547,7 +8547,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8796,7 +8796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9049,7 +9049,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9305,7 +9305,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9561,7 +9561,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9817,7 +9817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10073,7 +10073,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10329,7 +10329,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10585,7 +10585,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10841,7 +10841,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11097,7 +11097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11353,7 +11353,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11609,7 +11609,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11865,7 +11865,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12121,7 +12121,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12377,7 +12377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12633,7 +12633,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12889,7 +12889,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13145,7 +13145,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13402,7 +13402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13659,7 +13659,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13916,7 +13916,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14173,7 +14173,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14430,7 +14430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14687,7 +14687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14944,7 +14944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15201,7 +15201,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_custom.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_custom.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -274,7 +274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -534,7 +534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -793,7 +793,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1055,7 +1055,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1317,7 +1317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1577,7 +1577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1835,7 +1835,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2093,7 +2093,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2351,7 +2351,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2609,7 +2609,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2867,7 +2867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_AH_SAV.yaml
@@ -53,7 +53,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -223,7 +223,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -440,7 +440,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -657,7 +657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -874,7 +874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1092,7 +1092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1310,7 +1310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1527,7 +1527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1744,7 +1744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1961,7 +1961,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2178,7 +2178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2395,7 +2395,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2612,7 +2612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2829,7 +2829,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3046,7 +3046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3263,7 +3263,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3482,7 +3482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3701,7 +3701,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3925,7 +3925,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4151,7 +4151,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4373,7 +4373,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4592,7 +4592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4811,7 +4811,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5029,7 +5029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5247,7 +5247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5465,7 +5465,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5683,7 +5683,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5901,7 +5901,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_UserArgs.yaml
@@ -52,7 +52,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -437,7 +437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -653,7 +653,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -869,7 +869,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1085,7 +1085,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1301,7 +1301,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1517,7 +1517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1733,7 +1733,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1949,7 +1949,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2165,7 +2165,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2381,7 +2381,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2597,7 +2597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2813,7 +2813,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3029,7 +3029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3245,7 +3245,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3718,7 +3718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3934,7 +3934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4150,7 +4150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4381,7 +4381,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4618,7 +4618,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4855,7 +4855,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5092,7 +5092,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5329,7 +5329,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5566,7 +5566,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5803,7 +5803,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6040,7 +6040,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6282,7 +6282,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6526,7 +6526,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6770,7 +6770,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7014,7 +7014,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7258,7 +7258,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7502,7 +7502,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7741,7 +7741,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7983,7 +7983,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8227,7 +8227,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8471,7 +8471,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8718,7 +8718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8966,7 +8966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9218,7 +9218,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9474,7 +9474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9730,7 +9730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9986,7 +9986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10242,7 +10242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10498,7 +10498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10754,7 +10754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11010,7 +11010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11266,7 +11266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11522,7 +11522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11778,7 +11778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12034,7 +12034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12290,7 +12290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12546,7 +12546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12802,7 +12802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13058,7 +13058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13314,7 +13314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13570,7 +13570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13826,7 +13826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14082,7 +14082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14338,7 +14338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14594,7 +14594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14850,7 +14850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15106,7 +15106,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15362,7 +15362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15618,7 +15618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_custom.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_custom.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -273,7 +273,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -532,7 +532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -792,7 +792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1053,7 +1053,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1312,7 +1312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1570,7 +1570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1829,7 +1829,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2087,7 +2087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2345,7 +2345,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH.yaml
@@ -52,7 +52,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -437,7 +437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -653,7 +653,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -869,7 +869,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1085,7 +1085,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1301,7 +1301,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1517,7 +1517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1733,7 +1733,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1949,7 +1949,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2165,7 +2165,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2381,7 +2381,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2597,7 +2597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2813,7 +2813,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3029,7 +3029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3245,7 +3245,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3718,7 +3718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3934,7 +3934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4150,7 +4150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4381,7 +4381,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4618,7 +4618,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4855,7 +4855,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5092,7 +5092,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5329,7 +5329,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5566,7 +5566,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5803,7 +5803,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6040,7 +6040,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -6282,7 +6282,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6526,7 +6526,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6770,7 +6770,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7014,7 +7014,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7258,7 +7258,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7502,7 +7502,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7741,7 +7741,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -7983,7 +7983,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8227,7 +8227,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8471,7 +8471,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_AH_SAV.yaml
@@ -53,7 +53,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -223,7 +223,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -440,7 +440,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -657,7 +657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -874,7 +874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1092,7 +1092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1310,7 +1310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1527,7 +1527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1744,7 +1744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -1961,7 +1961,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2178,7 +2178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2395,7 +2395,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2612,7 +2612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -2829,7 +2829,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3046,7 +3046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3263,7 +3263,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3482,7 +3482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3701,7 +3701,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -3925,7 +3925,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4151,7 +4151,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4373,7 +4373,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4592,7 +4592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -4811,7 +4811,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5029,7 +5029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5247,7 +5247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5465,7 +5465,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5683,7 +5683,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false
@@ -5901,7 +5901,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_SB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_SB_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1566,7 +1566,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -269,7 +269,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -525,7 +525,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -781,7 +781,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1038,7 +1038,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1295,7 +1295,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1552,7 +1552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1809,7 +1809,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2066,7 +2066,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2323,7 +2323,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2580,7 +2580,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2837,7 +2837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3094,7 +3094,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3351,7 +3351,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3608,7 +3608,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3866,7 +3866,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4124,7 +4124,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4383,7 +4383,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4642,7 +4642,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8F8S_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8F8S_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1298,7 +1298,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1555,7 +1555,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1812,7 +1812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_HF8_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_HF8_HHS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1298,7 +1298,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1555,7 +1555,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1812,7 +1812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2069,7 +2069,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2326,7 +2326,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -269,7 +269,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -525,7 +525,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -781,7 +781,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1037,7 +1037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1293,7 +1293,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1549,7 +1549,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1805,7 +1805,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2061,7 +2061,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2317,7 +2317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2574,7 +2574,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_SB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_SB_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1566,7 +1566,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1825,7 +1825,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -269,7 +269,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -526,7 +526,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -783,7 +783,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1040,7 +1040,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1297,7 +1297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1554,7 +1554,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1811,7 +1811,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2068,7 +2068,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2325,7 +2325,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2582,7 +2582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2839,7 +2839,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3096,7 +3096,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3353,7 +3353,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3610,7 +3610,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3867,7 +3867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4124,7 +4124,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4381,7 +4381,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4638,7 +4638,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4895,7 +4895,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5152,7 +5152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5409,7 +5409,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5666,7 +5666,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5923,7 +5923,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6180,7 +6180,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6437,7 +6437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6694,7 +6694,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6951,7 +6951,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7208,7 +7208,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7465,7 +7465,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7722,7 +7722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7979,7 +7979,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8236,7 +8236,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8493,7 +8493,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8750,7 +8750,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9007,7 +9007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9264,7 +9264,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9521,7 +9521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9778,7 +9778,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10035,7 +10035,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10292,7 +10292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10549,7 +10549,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10806,7 +10806,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11063,7 +11063,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11320,7 +11320,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11577,7 +11577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11834,7 +11834,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12091,7 +12091,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12348,7 +12348,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12605,7 +12605,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12862,7 +12862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13119,7 +13119,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13376,7 +13376,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13633,7 +13633,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13890,7 +13890,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14147,7 +14147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14404,7 +14404,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14661,7 +14661,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14918,7 +14918,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15175,7 +15175,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15432,7 +15432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15689,7 +15689,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15946,7 +15946,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16203,7 +16203,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16460,7 +16460,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16717,7 +16717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16974,7 +16974,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17231,7 +17231,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17488,7 +17488,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17745,7 +17745,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18002,7 +18002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18259,7 +18259,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18516,7 +18516,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18773,7 +18773,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19030,7 +19030,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19287,7 +19287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19544,7 +19544,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19801,7 +19801,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20058,7 +20058,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20315,7 +20315,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20572,7 +20572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20829,7 +20829,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21086,7 +21086,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21343,7 +21343,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21600,7 +21600,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21857,7 +21857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22114,7 +22114,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22371,7 +22371,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22628,7 +22628,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22885,7 +22885,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23142,7 +23142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23399,7 +23399,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23656,7 +23656,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23913,7 +23913,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24170,7 +24170,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24427,7 +24427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24684,7 +24684,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24941,7 +24941,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25198,7 +25198,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25455,7 +25455,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25712,7 +25712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25969,7 +25969,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26226,7 +26226,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26483,7 +26483,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26740,7 +26740,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26997,7 +26997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27254,7 +27254,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27511,7 +27511,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27768,7 +27768,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28025,7 +28025,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28282,7 +28282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28539,7 +28539,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28796,7 +28796,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29053,7 +29053,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29310,7 +29310,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29567,7 +29567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29824,7 +29824,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30081,7 +30081,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30338,7 +30338,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30595,7 +30595,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30852,7 +30852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31109,7 +31109,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31366,7 +31366,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31623,7 +31623,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31880,7 +31880,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32137,7 +32137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32394,7 +32394,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32651,7 +32651,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32908,7 +32908,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33165,7 +33165,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33422,7 +33422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33679,7 +33679,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33936,7 +33936,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34193,7 +34193,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34450,7 +34450,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34707,7 +34707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34964,7 +34964,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35221,7 +35221,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35478,7 +35478,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35735,7 +35735,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35992,7 +35992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36249,7 +36249,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36506,7 +36506,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36763,7 +36763,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37020,7 +37020,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37277,7 +37277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37534,7 +37534,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37791,7 +37791,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38048,7 +38048,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38305,7 +38305,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38562,7 +38562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38819,7 +38819,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39076,7 +39076,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39333,7 +39333,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39590,7 +39590,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39847,7 +39847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40104,7 +40104,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40361,7 +40361,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40618,7 +40618,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40875,7 +40875,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41132,7 +41132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41389,7 +41389,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41646,7 +41646,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41903,7 +41903,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42160,7 +42160,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42417,7 +42417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42674,7 +42674,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42931,7 +42931,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43188,7 +43188,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43445,7 +43445,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43702,7 +43702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43959,7 +43959,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44216,7 +44216,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44473,7 +44473,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44730,7 +44730,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44987,7 +44987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45244,7 +45244,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45501,7 +45501,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45758,7 +45758,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46015,7 +46015,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46272,7 +46272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46529,7 +46529,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46786,7 +46786,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47043,7 +47043,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47300,7 +47300,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47557,7 +47557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47814,7 +47814,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48071,7 +48071,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48328,7 +48328,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48585,7 +48585,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48842,7 +48842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49099,7 +49099,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49356,7 +49356,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49613,7 +49613,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49870,7 +49870,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50127,7 +50127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50384,7 +50384,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50641,7 +50641,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50898,7 +50898,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51155,7 +51155,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51412,7 +51412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51669,7 +51669,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51926,7 +51926,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52183,7 +52183,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52440,7 +52440,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52697,7 +52697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52954,7 +52954,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53211,7 +53211,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53468,7 +53468,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53725,7 +53725,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53982,7 +53982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54239,7 +54239,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54496,7 +54496,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54753,7 +54753,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55010,7 +55010,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55267,7 +55267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55524,7 +55524,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55781,7 +55781,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56038,7 +56038,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56295,7 +56295,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56552,7 +56552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56809,7 +56809,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57066,7 +57066,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57323,7 +57323,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57580,7 +57580,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57837,7 +57837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58094,7 +58094,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58351,7 +58351,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58608,7 +58608,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58865,7 +58865,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59122,7 +59122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59379,7 +59379,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59636,7 +59636,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59893,7 +59893,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60150,7 +60150,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60407,7 +60407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60664,7 +60664,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60921,7 +60921,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61178,7 +61178,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61435,7 +61435,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61692,7 +61692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61949,7 +61949,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62206,7 +62206,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62463,7 +62463,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62720,7 +62720,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62977,7 +62977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63234,7 +63234,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63491,7 +63491,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63748,7 +63748,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64005,7 +64005,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64262,7 +64262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64519,7 +64519,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64776,7 +64776,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65033,7 +65033,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65804,7 +65804,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66061,7 +66061,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66318,7 +66318,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66575,7 +66575,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66832,7 +66832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67089,7 +67089,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67346,7 +67346,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67603,7 +67603,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67860,7 +67860,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68117,7 +68117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68374,7 +68374,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68631,7 +68631,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68888,7 +68888,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69145,7 +69145,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69402,7 +69402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69659,7 +69659,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69916,7 +69916,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70173,7 +70173,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70430,7 +70430,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70687,7 +70687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70944,7 +70944,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71201,7 +71201,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71458,7 +71458,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71715,7 +71715,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71972,7 +71972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72229,7 +72229,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72486,7 +72486,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72743,7 +72743,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73000,7 +73000,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73257,7 +73257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73514,7 +73514,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73771,7 +73771,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74028,7 +74028,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74285,7 +74285,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74542,7 +74542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74799,7 +74799,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75056,7 +75056,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75313,7 +75313,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75570,7 +75570,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75827,7 +75827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76084,7 +76084,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76341,7 +76341,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76598,7 +76598,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76855,7 +76855,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77112,7 +77112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77369,7 +77369,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77626,7 +77626,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77883,7 +77883,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78140,7 +78140,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78397,7 +78397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78654,7 +78654,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78911,7 +78911,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79168,7 +79168,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79425,7 +79425,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79682,7 +79682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79939,7 +79939,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80196,7 +80196,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80453,7 +80453,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80710,7 +80710,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80967,7 +80967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81224,7 +81224,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81481,7 +81481,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81738,7 +81738,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81995,7 +81995,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82252,7 +82252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82509,7 +82509,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82766,7 +82766,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83023,7 +83023,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83280,7 +83280,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83537,7 +83537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83794,7 +83794,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84051,7 +84051,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84308,7 +84308,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84565,7 +84565,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84822,7 +84822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85079,7 +85079,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85336,7 +85336,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85593,7 +85593,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85850,7 +85850,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86107,7 +86107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86364,7 +86364,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86621,7 +86621,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86878,7 +86878,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87135,7 +87135,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87392,7 +87392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87649,7 +87649,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87906,7 +87906,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88163,7 +88163,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88420,7 +88420,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88677,7 +88677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88934,7 +88934,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89191,7 +89191,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89448,7 +89448,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89705,7 +89705,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89962,7 +89962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90219,7 +90219,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90476,7 +90476,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90733,7 +90733,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90990,7 +90990,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91247,7 +91247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91504,7 +91504,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91761,7 +91761,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92018,7 +92018,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92275,7 +92275,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92532,7 +92532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92789,7 +92789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93046,7 +93046,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93303,7 +93303,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93560,7 +93560,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93817,7 +93817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94074,7 +94074,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94331,7 +94331,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94588,7 +94588,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94845,7 +94845,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95102,7 +95102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95359,7 +95359,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95616,7 +95616,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95873,7 +95873,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96130,7 +96130,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96387,7 +96387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96644,7 +96644,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96901,7 +96901,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97158,7 +97158,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97415,7 +97415,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97672,7 +97672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97929,7 +97929,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98186,7 +98186,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98443,7 +98443,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98700,7 +98700,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98957,7 +98957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99214,7 +99214,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99471,7 +99471,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99728,7 +99728,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99985,7 +99985,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100242,7 +100242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100499,7 +100499,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100756,7 +100756,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101013,7 +101013,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101270,7 +101270,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101527,7 +101527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101784,7 +101784,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102041,7 +102041,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102298,7 +102298,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102555,7 +102555,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102812,7 +102812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103069,7 +103069,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103326,7 +103326,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103583,7 +103583,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103840,7 +103840,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104097,7 +104097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104354,7 +104354,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104611,7 +104611,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104868,7 +104868,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105125,7 +105125,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105382,7 +105382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105639,7 +105639,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105896,7 +105896,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106153,7 +106153,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106410,7 +106410,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106667,7 +106667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106924,7 +106924,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107181,7 +107181,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107438,7 +107438,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107695,7 +107695,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107952,7 +107952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108209,7 +108209,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108466,7 +108466,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108723,7 +108723,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108980,7 +108980,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109237,7 +109237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109494,7 +109494,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109751,7 +109751,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110008,7 +110008,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110265,7 +110265,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110522,7 +110522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110779,7 +110779,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111036,7 +111036,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111293,7 +111293,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111550,7 +111550,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111807,7 +111807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112064,7 +112064,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112321,7 +112321,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112578,7 +112578,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112835,7 +112835,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113092,7 +113092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113349,7 +113349,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113606,7 +113606,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113863,7 +113863,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114120,7 +114120,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114377,7 +114377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114634,7 +114634,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114891,7 +114891,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115148,7 +115148,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115405,7 +115405,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115662,7 +115662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115919,7 +115919,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116176,7 +116176,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116433,7 +116433,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116690,7 +116690,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116947,7 +116947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117204,7 +117204,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117461,7 +117461,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117718,7 +117718,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117975,7 +117975,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118232,7 +118232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118489,7 +118489,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118746,7 +118746,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119003,7 +119003,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119260,7 +119260,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119517,7 +119517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119774,7 +119774,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120031,7 +120031,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120288,7 +120288,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120545,7 +120545,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120802,7 +120802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121059,7 +121059,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121316,7 +121316,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121573,7 +121573,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121830,7 +121830,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122087,7 +122087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122344,7 +122344,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122601,7 +122601,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122858,7 +122858,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123115,7 +123115,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123372,7 +123372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123629,7 +123629,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123886,7 +123886,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124143,7 +124143,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124400,7 +124400,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124657,7 +124657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124914,7 +124914,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125171,7 +125171,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125428,7 +125428,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125685,7 +125685,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125942,7 +125942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126199,7 +126199,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126456,7 +126456,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126713,7 +126713,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126970,7 +126970,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127227,7 +127227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127484,7 +127484,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127741,7 +127741,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127998,7 +127998,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -128255,7 +128255,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -128512,7 +128512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -128769,7 +128769,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129026,7 +129026,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129283,7 +129283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129540,7 +129540,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129797,7 +129797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130054,7 +130054,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130311,7 +130311,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130568,7 +130568,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130825,7 +130825,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131082,7 +131082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131339,7 +131339,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131596,7 +131596,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131853,7 +131853,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132110,7 +132110,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132367,7 +132367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132624,7 +132624,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132881,7 +132881,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133138,7 +133138,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133395,7 +133395,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133652,7 +133652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133909,7 +133909,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134166,7 +134166,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134423,7 +134423,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134680,7 +134680,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134937,7 +134937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135194,7 +135194,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135451,7 +135451,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135708,7 +135708,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135965,7 +135965,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136222,7 +136222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136479,7 +136479,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136736,7 +136736,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136993,7 +136993,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -137250,7 +137250,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -137507,7 +137507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -137764,7 +137764,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138021,7 +138021,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138278,7 +138278,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138535,7 +138535,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138792,7 +138792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139049,7 +139049,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139306,7 +139306,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139563,7 +139563,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139820,7 +139820,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -140077,7 +140077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -140334,7 +140334,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -140591,7 +140591,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -140848,7 +140848,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -141105,7 +141105,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117570,7 +117570,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117828,7 +117828,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118086,7 +118086,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118344,7 +118344,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118602,7 +118602,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118860,7 +118860,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119118,7 +119118,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119376,7 +119376,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119634,7 +119634,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119892,7 +119892,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120150,7 +120150,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120408,7 +120408,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120663,7 +120663,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120918,7 +120918,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121173,7 +121173,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121428,7 +121428,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121686,7 +121686,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121944,7 +121944,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122202,7 +122202,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122460,7 +122460,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122718,7 +122718,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_GG_SAB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_GG_SAB_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117109,7 +117109,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117366,7 +117366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117623,7 +117623,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117570,7 +117570,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117828,7 +117828,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118086,7 +118086,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118344,7 +118344,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118602,7 +118602,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118860,7 +118860,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119118,7 +119118,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119376,7 +119376,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119634,7 +119634,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119892,7 +119892,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120150,7 +120150,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120408,7 +120408,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120663,7 +120663,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120918,7 +120918,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121173,7 +121173,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121428,7 +121428,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121686,7 +121686,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121944,7 +121944,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122202,7 +122202,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122460,7 +122460,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122718,7 +122718,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_GG_SAB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_GG_SAB_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_GG_SAB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_GG_SAB_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_GG_SAB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_GG_SAB_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_SAB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_SAB_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1537,7 +1537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1791,7 +1791,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2045,7 +2045,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2299,7 +2299,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2553,7 +2553,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2807,7 +2807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3061,7 +3061,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3315,7 +3315,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3569,7 +3569,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3823,7 +3823,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4077,7 +4077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4331,7 +4331,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4585,7 +4585,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4839,7 +4839,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5093,7 +5093,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5347,7 +5347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5601,7 +5601,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5855,7 +5855,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6109,7 +6109,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6363,7 +6363,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6617,7 +6617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6871,7 +6871,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7125,7 +7125,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7379,7 +7379,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7633,7 +7633,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7887,7 +7887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8141,7 +8141,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8395,7 +8395,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8649,7 +8649,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8903,7 +8903,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9157,7 +9157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9411,7 +9411,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9665,7 +9665,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9919,7 +9919,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10173,7 +10173,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10427,7 +10427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10681,7 +10681,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10935,7 +10935,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11189,7 +11189,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11443,7 +11443,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11697,7 +11697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11951,7 +11951,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12205,7 +12205,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12459,7 +12459,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12713,7 +12713,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12967,7 +12967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13221,7 +13221,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13475,7 +13475,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13729,7 +13729,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13983,7 +13983,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14237,7 +14237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14491,7 +14491,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14745,7 +14745,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14999,7 +14999,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15253,7 +15253,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15507,7 +15507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15761,7 +15761,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16015,7 +16015,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16269,7 +16269,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16523,7 +16523,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16777,7 +16777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17031,7 +17031,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17285,7 +17285,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17539,7 +17539,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17793,7 +17793,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18047,7 +18047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18301,7 +18301,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18555,7 +18555,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18809,7 +18809,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19063,7 +19063,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19317,7 +19317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19571,7 +19571,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19825,7 +19825,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20079,7 +20079,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20333,7 +20333,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20587,7 +20587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20841,7 +20841,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21095,7 +21095,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21349,7 +21349,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21603,7 +21603,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21857,7 +21857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22111,7 +22111,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22365,7 +22365,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22619,7 +22619,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22873,7 +22873,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23127,7 +23127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23381,7 +23381,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23635,7 +23635,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23889,7 +23889,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24143,7 +24143,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24397,7 +24397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24651,7 +24651,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24905,7 +24905,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25159,7 +25159,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25413,7 +25413,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25667,7 +25667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25921,7 +25921,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26175,7 +26175,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26429,7 +26429,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26683,7 +26683,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26937,7 +26937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27191,7 +27191,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27445,7 +27445,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27699,7 +27699,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27953,7 +27953,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28207,7 +28207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28461,7 +28461,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28715,7 +28715,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28969,7 +28969,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29223,7 +29223,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29477,7 +29477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29731,7 +29731,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29985,7 +29985,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30239,7 +30239,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30493,7 +30493,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30747,7 +30747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31001,7 +31001,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31255,7 +31255,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31509,7 +31509,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31763,7 +31763,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32017,7 +32017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32271,7 +32271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32525,7 +32525,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32779,7 +32779,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33033,7 +33033,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33287,7 +33287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33541,7 +33541,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33795,7 +33795,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34049,7 +34049,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34303,7 +34303,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34557,7 +34557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34811,7 +34811,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35065,7 +35065,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35319,7 +35319,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35573,7 +35573,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35827,7 +35827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36081,7 +36081,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36335,7 +36335,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36589,7 +36589,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36843,7 +36843,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37097,7 +37097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37351,7 +37351,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37605,7 +37605,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37859,7 +37859,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38113,7 +38113,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38367,7 +38367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38621,7 +38621,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38875,7 +38875,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39129,7 +39129,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39383,7 +39383,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39637,7 +39637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39891,7 +39891,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40145,7 +40145,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40399,7 +40399,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40653,7 +40653,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40907,7 +40907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41161,7 +41161,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41415,7 +41415,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41669,7 +41669,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41923,7 +41923,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117570,7 +117570,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117827,7 +117827,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118084,7 +118084,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118341,7 +118341,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118598,7 +118598,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118855,7 +118855,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119112,7 +119112,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119369,7 +119369,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119623,7 +119623,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119877,7 +119877,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120131,7 +120131,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120385,7 +120385,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120642,7 +120642,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120899,7 +120899,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121156,7 +121156,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121413,7 +121413,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121670,7 +121670,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121927,7 +121927,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122184,7 +122184,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_GG_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_GG_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113487,7 +113487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113742,7 +113742,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113997,7 +113997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114252,7 +114252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114507,7 +114507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114762,7 +114762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115017,7 +115017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115272,7 +115272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115527,7 +115527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115782,7 +115782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116037,7 +116037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116292,7 +116292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116547,7 +116547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116802,7 +116802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117057,7 +117057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117312,7 +117312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117570,7 +117570,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117827,7 +117827,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118084,7 +118084,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118341,7 +118341,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118598,7 +118598,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118855,7 +118855,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119112,7 +119112,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119369,7 +119369,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119623,7 +119623,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119877,7 +119877,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120131,7 +120131,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120385,7 +120385,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120642,7 +120642,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120899,7 +120899,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121156,7 +121156,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121413,7 +121413,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121670,7 +121670,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121927,7 +121927,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122184,7 +122184,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_GG_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_GG_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -266,7 +266,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -520,7 +520,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -774,7 +774,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1028,7 +1028,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1282,7 +1282,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1536,7 +1536,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1790,7 +1790,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2044,7 +2044,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2298,7 +2298,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2552,7 +2552,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2806,7 +2806,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3060,7 +3060,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3314,7 +3314,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3568,7 +3568,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3822,7 +3822,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4076,7 +4076,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4330,7 +4330,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4584,7 +4584,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4838,7 +4838,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5092,7 +5092,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5346,7 +5346,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5600,7 +5600,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5854,7 +5854,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6108,7 +6108,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6362,7 +6362,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6616,7 +6616,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6870,7 +6870,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7124,7 +7124,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7378,7 +7378,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7632,7 +7632,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7886,7 +7886,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8140,7 +8140,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8394,7 +8394,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8648,7 +8648,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8902,7 +8902,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9156,7 +9156,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9410,7 +9410,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9664,7 +9664,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9918,7 +9918,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10172,7 +10172,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10426,7 +10426,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10680,7 +10680,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10934,7 +10934,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11188,7 +11188,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11442,7 +11442,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11696,7 +11696,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11950,7 +11950,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12204,7 +12204,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12458,7 +12458,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12712,7 +12712,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12966,7 +12966,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13220,7 +13220,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13474,7 +13474,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13728,7 +13728,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13982,7 +13982,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14236,7 +14236,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14490,7 +14490,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14744,7 +14744,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14998,7 +14998,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15252,7 +15252,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15506,7 +15506,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15760,7 +15760,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16014,7 +16014,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16268,7 +16268,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16522,7 +16522,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16776,7 +16776,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17030,7 +17030,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17284,7 +17284,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17538,7 +17538,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17792,7 +17792,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18046,7 +18046,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18300,7 +18300,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18554,7 +18554,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18808,7 +18808,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19062,7 +19062,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19316,7 +19316,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19570,7 +19570,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19824,7 +19824,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20078,7 +20078,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20332,7 +20332,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20586,7 +20586,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20840,7 +20840,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21094,7 +21094,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21348,7 +21348,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21602,7 +21602,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21856,7 +21856,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22110,7 +22110,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22364,7 +22364,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22618,7 +22618,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22872,7 +22872,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23126,7 +23126,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23380,7 +23380,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23634,7 +23634,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23888,7 +23888,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24142,7 +24142,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24396,7 +24396,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24650,7 +24650,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24904,7 +24904,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25158,7 +25158,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25412,7 +25412,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25666,7 +25666,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25920,7 +25920,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26174,7 +26174,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26428,7 +26428,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26682,7 +26682,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26936,7 +26936,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27190,7 +27190,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27444,7 +27444,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27698,7 +27698,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27952,7 +27952,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28206,7 +28206,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28460,7 +28460,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28714,7 +28714,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28968,7 +28968,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29222,7 +29222,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29476,7 +29476,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29730,7 +29730,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29984,7 +29984,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30238,7 +30238,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30492,7 +30492,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30746,7 +30746,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31000,7 +31000,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31254,7 +31254,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31508,7 +31508,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31762,7 +31762,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32016,7 +32016,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32270,7 +32270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32524,7 +32524,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32778,7 +32778,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33032,7 +33032,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33286,7 +33286,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33540,7 +33540,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33794,7 +33794,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34048,7 +34048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34302,7 +34302,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34556,7 +34556,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34810,7 +34810,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35064,7 +35064,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35318,7 +35318,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35572,7 +35572,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35826,7 +35826,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36080,7 +36080,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36334,7 +36334,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36588,7 +36588,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36842,7 +36842,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37096,7 +37096,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37350,7 +37350,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37604,7 +37604,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37858,7 +37858,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38112,7 +38112,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38366,7 +38366,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38620,7 +38620,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38874,7 +38874,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39128,7 +39128,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39382,7 +39382,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39636,7 +39636,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39890,7 +39890,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40144,7 +40144,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40398,7 +40398,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40652,7 +40652,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40906,7 +40906,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41160,7 +41160,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41414,7 +41414,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41668,7 +41668,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41922,7 +41922,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42176,7 +42176,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42430,7 +42430,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42684,7 +42684,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42938,7 +42938,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43192,7 +43192,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43446,7 +43446,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43700,7 +43700,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43954,7 +43954,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44208,7 +44208,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44462,7 +44462,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44716,7 +44716,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44970,7 +44970,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45224,7 +45224,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45478,7 +45478,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45732,7 +45732,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45986,7 +45986,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46240,7 +46240,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46494,7 +46494,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46748,7 +46748,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47002,7 +47002,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47256,7 +47256,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47510,7 +47510,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47764,7 +47764,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48018,7 +48018,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48272,7 +48272,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48526,7 +48526,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48780,7 +48780,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49034,7 +49034,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49288,7 +49288,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49542,7 +49542,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49796,7 +49796,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50050,7 +50050,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50304,7 +50304,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50558,7 +50558,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50812,7 +50812,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51066,7 +51066,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51320,7 +51320,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51574,7 +51574,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51828,7 +51828,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52082,7 +52082,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52336,7 +52336,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52590,7 +52590,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52844,7 +52844,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53098,7 +53098,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53352,7 +53352,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53606,7 +53606,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53860,7 +53860,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54114,7 +54114,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54368,7 +54368,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54622,7 +54622,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54876,7 +54876,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55130,7 +55130,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55384,7 +55384,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55638,7 +55638,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55892,7 +55892,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56146,7 +56146,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56400,7 +56400,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56654,7 +56654,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56908,7 +56908,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57162,7 +57162,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57416,7 +57416,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57670,7 +57670,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57924,7 +57924,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58178,7 +58178,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58432,7 +58432,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58686,7 +58686,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58940,7 +58940,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59194,7 +59194,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59448,7 +59448,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59702,7 +59702,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59956,7 +59956,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60210,7 +60210,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60464,7 +60464,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60718,7 +60718,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60972,7 +60972,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61226,7 +61226,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61480,7 +61480,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61734,7 +61734,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61988,7 +61988,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62242,7 +62242,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62496,7 +62496,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62750,7 +62750,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63004,7 +63004,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63258,7 +63258,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63512,7 +63512,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63766,7 +63766,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64020,7 +64020,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64274,7 +64274,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64528,7 +64528,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65036,7 +65036,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65290,7 +65290,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65544,7 +65544,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65798,7 +65798,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66052,7 +66052,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66306,7 +66306,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66560,7 +66560,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66814,7 +66814,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67068,7 +67068,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67322,7 +67322,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67576,7 +67576,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67830,7 +67830,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68084,7 +68084,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68338,7 +68338,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68592,7 +68592,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68846,7 +68846,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69100,7 +69100,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69354,7 +69354,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69608,7 +69608,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69862,7 +69862,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70116,7 +70116,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70370,7 +70370,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70624,7 +70624,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70878,7 +70878,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71132,7 +71132,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71386,7 +71386,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71640,7 +71640,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71894,7 +71894,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72148,7 +72148,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72402,7 +72402,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72656,7 +72656,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72910,7 +72910,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73164,7 +73164,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73418,7 +73418,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73672,7 +73672,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73926,7 +73926,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74180,7 +74180,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74434,7 +74434,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74688,7 +74688,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74942,7 +74942,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75196,7 +75196,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75450,7 +75450,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75704,7 +75704,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75958,7 +75958,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76212,7 +76212,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76466,7 +76466,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76720,7 +76720,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76974,7 +76974,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77228,7 +77228,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77482,7 +77482,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77736,7 +77736,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77990,7 +77990,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78244,7 +78244,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78498,7 +78498,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78752,7 +78752,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79006,7 +79006,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79260,7 +79260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79514,7 +79514,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79768,7 +79768,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80022,7 +80022,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80276,7 +80276,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80530,7 +80530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80784,7 +80784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81038,7 +81038,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81292,7 +81292,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81546,7 +81546,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81800,7 +81800,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82054,7 +82054,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82308,7 +82308,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82562,7 +82562,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82816,7 +82816,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83070,7 +83070,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83324,7 +83324,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83578,7 +83578,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83832,7 +83832,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84086,7 +84086,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84340,7 +84340,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84594,7 +84594,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84848,7 +84848,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85102,7 +85102,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85356,7 +85356,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85610,7 +85610,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85864,7 +85864,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86118,7 +86118,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86372,7 +86372,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86626,7 +86626,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86880,7 +86880,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87134,7 +87134,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87388,7 +87388,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87642,7 +87642,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87896,7 +87896,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88150,7 +88150,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88404,7 +88404,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88658,7 +88658,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88912,7 +88912,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89166,7 +89166,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89420,7 +89420,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89674,7 +89674,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89928,7 +89928,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90182,7 +90182,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90436,7 +90436,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90690,7 +90690,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90944,7 +90944,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91198,7 +91198,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91452,7 +91452,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91706,7 +91706,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91960,7 +91960,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92214,7 +92214,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92468,7 +92468,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92722,7 +92722,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92976,7 +92976,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93230,7 +93230,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93484,7 +93484,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93738,7 +93738,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93992,7 +93992,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94246,7 +94246,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94500,7 +94500,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94754,7 +94754,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95008,7 +95008,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95262,7 +95262,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95516,7 +95516,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95770,7 +95770,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96024,7 +96024,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96278,7 +96278,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96532,7 +96532,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96786,7 +96786,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97040,7 +97040,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97294,7 +97294,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97548,7 +97548,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97802,7 +97802,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98056,7 +98056,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98310,7 +98310,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98564,7 +98564,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98818,7 +98818,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99072,7 +99072,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99326,7 +99326,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99580,7 +99580,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99834,7 +99834,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100088,7 +100088,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100342,7 +100342,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100596,7 +100596,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100850,7 +100850,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101104,7 +101104,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101358,7 +101358,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101612,7 +101612,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101866,7 +101866,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102120,7 +102120,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102374,7 +102374,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102628,7 +102628,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102882,7 +102882,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103136,7 +103136,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103390,7 +103390,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103644,7 +103644,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103898,7 +103898,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104152,7 +104152,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104406,7 +104406,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104660,7 +104660,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104914,7 +104914,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105168,7 +105168,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105422,7 +105422,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105676,7 +105676,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105930,7 +105930,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106184,7 +106184,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106438,7 +106438,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106692,7 +106692,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106946,7 +106946,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107200,7 +107200,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107454,7 +107454,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107708,7 +107708,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107962,7 +107962,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108216,7 +108216,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108470,7 +108470,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108724,7 +108724,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108978,7 +108978,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109232,7 +109232,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109486,7 +109486,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109740,7 +109740,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109994,7 +109994,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110248,7 +110248,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110502,7 +110502,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110756,7 +110756,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111010,7 +111010,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111264,7 +111264,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111518,7 +111518,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111772,7 +111772,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112026,7 +112026,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112280,7 +112280,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112534,7 +112534,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112788,7 +112788,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113042,7 +113042,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113296,7 +113296,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113550,7 +113550,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113804,7 +113804,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114058,7 +114058,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114312,7 +114312,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114566,7 +114566,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114820,7 +114820,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115074,7 +115074,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115328,7 +115328,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115582,7 +115582,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115836,7 +115836,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116090,7 +116090,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116344,7 +116344,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116598,7 +116598,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116852,7 +116852,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_Bias_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_Bias_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HF8_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HF8_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1537,7 +1537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1791,7 +1791,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2045,7 +2045,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2299,7 +2299,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2553,7 +2553,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2807,7 +2807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3061,7 +3061,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3315,7 +3315,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3569,7 +3569,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3823,7 +3823,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4077,7 +4077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4331,7 +4331,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4585,7 +4585,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4839,7 +4839,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5093,7 +5093,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5347,7 +5347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5601,7 +5601,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5855,7 +5855,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6109,7 +6109,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6363,7 +6363,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6617,7 +6617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6871,7 +6871,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7125,7 +7125,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7379,7 +7379,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7633,7 +7633,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7887,7 +7887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8141,7 +8141,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8395,7 +8395,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8649,7 +8649,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8903,7 +8903,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9157,7 +9157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9411,7 +9411,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9665,7 +9665,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9919,7 +9919,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10173,7 +10173,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10427,7 +10427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10681,7 +10681,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10935,7 +10935,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11189,7 +11189,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11443,7 +11443,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11697,7 +11697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11951,7 +11951,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12205,7 +12205,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12459,7 +12459,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12713,7 +12713,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12967,7 +12967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13221,7 +13221,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13475,7 +13475,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13729,7 +13729,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13983,7 +13983,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14237,7 +14237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14491,7 +14491,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14745,7 +14745,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14999,7 +14999,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15253,7 +15253,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15507,7 +15507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15761,7 +15761,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16015,7 +16015,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16269,7 +16269,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16523,7 +16523,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16777,7 +16777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17031,7 +17031,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17285,7 +17285,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17539,7 +17539,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17793,7 +17793,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18047,7 +18047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18301,7 +18301,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18555,7 +18555,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18809,7 +18809,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19063,7 +19063,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19317,7 +19317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19571,7 +19571,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19825,7 +19825,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20079,7 +20079,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20333,7 +20333,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20587,7 +20587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20841,7 +20841,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21095,7 +21095,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21349,7 +21349,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21603,7 +21603,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21857,7 +21857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22111,7 +22111,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22365,7 +22365,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22619,7 +22619,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22873,7 +22873,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23127,7 +23127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23381,7 +23381,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23635,7 +23635,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23889,7 +23889,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24143,7 +24143,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24397,7 +24397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24651,7 +24651,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24905,7 +24905,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25159,7 +25159,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25413,7 +25413,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25667,7 +25667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25921,7 +25921,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26175,7 +26175,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26429,7 +26429,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26683,7 +26683,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26937,7 +26937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27191,7 +27191,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27445,7 +27445,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27699,7 +27699,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27953,7 +27953,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28207,7 +28207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28461,7 +28461,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28715,7 +28715,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28969,7 +28969,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29223,7 +29223,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29477,7 +29477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29731,7 +29731,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29985,7 +29985,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30239,7 +30239,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30493,7 +30493,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30747,7 +30747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31001,7 +31001,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31255,7 +31255,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31509,7 +31509,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31763,7 +31763,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32017,7 +32017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32271,7 +32271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32525,7 +32525,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32779,7 +32779,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33033,7 +33033,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33287,7 +33287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33541,7 +33541,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33795,7 +33795,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34049,7 +34049,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34303,7 +34303,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34557,7 +34557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34811,7 +34811,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35065,7 +35065,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35319,7 +35319,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35573,7 +35573,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35827,7 +35827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36081,7 +36081,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36335,7 +36335,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36589,7 +36589,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36843,7 +36843,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37097,7 +37097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37351,7 +37351,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37605,7 +37605,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37859,7 +37859,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38113,7 +38113,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38367,7 +38367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38621,7 +38621,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38875,7 +38875,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39129,7 +39129,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39383,7 +39383,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39637,7 +39637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39891,7 +39891,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40145,7 +40145,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40399,7 +40399,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40653,7 +40653,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40907,7 +40907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41161,7 +41161,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41415,7 +41415,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41669,7 +41669,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41923,7 +41923,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42177,7 +42177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42431,7 +42431,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42685,7 +42685,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42939,7 +42939,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43193,7 +43193,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43447,7 +43447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43701,7 +43701,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43955,7 +43955,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44209,7 +44209,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44463,7 +44463,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44717,7 +44717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44971,7 +44971,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45225,7 +45225,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45479,7 +45479,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45733,7 +45733,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45987,7 +45987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46244,7 +46244,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -522,7 +522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -777,7 +777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1032,7 +1032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1287,7 +1287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1542,7 +1542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1797,7 +1797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2052,7 +2052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2307,7 +2307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2562,7 +2562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2817,7 +2817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3072,7 +3072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3327,7 +3327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3582,7 +3582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3837,7 +3837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4092,7 +4092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4347,7 +4347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4602,7 +4602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4857,7 +4857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5112,7 +5112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5367,7 +5367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5622,7 +5622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5877,7 +5877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6132,7 +6132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6387,7 +6387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6642,7 +6642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6897,7 +6897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7152,7 +7152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7407,7 +7407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7662,7 +7662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7917,7 +7917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8172,7 +8172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8427,7 +8427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8682,7 +8682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8937,7 +8937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9192,7 +9192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9447,7 +9447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9702,7 +9702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9957,7 +9957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10212,7 +10212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10467,7 +10467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10722,7 +10722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10977,7 +10977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11232,7 +11232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11487,7 +11487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11742,7 +11742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11997,7 +11997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12252,7 +12252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12507,7 +12507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12762,7 +12762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13017,7 +13017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13272,7 +13272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13527,7 +13527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13782,7 +13782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14037,7 +14037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14292,7 +14292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14547,7 +14547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14802,7 +14802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15057,7 +15057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15312,7 +15312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15567,7 +15567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15822,7 +15822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16077,7 +16077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16332,7 +16332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16587,7 +16587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16842,7 +16842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17097,7 +17097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17352,7 +17352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17607,7 +17607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17862,7 +17862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18117,7 +18117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18372,7 +18372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18627,7 +18627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18882,7 +18882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19137,7 +19137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19392,7 +19392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19647,7 +19647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19902,7 +19902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20157,7 +20157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20412,7 +20412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20667,7 +20667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20922,7 +20922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21177,7 +21177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21432,7 +21432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21687,7 +21687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21942,7 +21942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22197,7 +22197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22452,7 +22452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22707,7 +22707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22962,7 +22962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23217,7 +23217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23472,7 +23472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23727,7 +23727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23982,7 +23982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24237,7 +24237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24492,7 +24492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24747,7 +24747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25002,7 +25002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25257,7 +25257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25512,7 +25512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25767,7 +25767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26022,7 +26022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26277,7 +26277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26532,7 +26532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26787,7 +26787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27042,7 +27042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27297,7 +27297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27552,7 +27552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27807,7 +27807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28062,7 +28062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28317,7 +28317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28572,7 +28572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28827,7 +28827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29082,7 +29082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29337,7 +29337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29592,7 +29592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29847,7 +29847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30102,7 +30102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30357,7 +30357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30612,7 +30612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30867,7 +30867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31122,7 +31122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31377,7 +31377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31632,7 +31632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31887,7 +31887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32142,7 +32142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32397,7 +32397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32652,7 +32652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32907,7 +32907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33162,7 +33162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33417,7 +33417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33672,7 +33672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33927,7 +33927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34182,7 +34182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34437,7 +34437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34692,7 +34692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34947,7 +34947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35202,7 +35202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35457,7 +35457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35712,7 +35712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35967,7 +35967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36222,7 +36222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36477,7 +36477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36732,7 +36732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36987,7 +36987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37242,7 +37242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37497,7 +37497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37752,7 +37752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38007,7 +38007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38262,7 +38262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38517,7 +38517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38772,7 +38772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39027,7 +39027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39282,7 +39282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39537,7 +39537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39792,7 +39792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40047,7 +40047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40302,7 +40302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40557,7 +40557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40812,7 +40812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41067,7 +41067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41322,7 +41322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41577,7 +41577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41832,7 +41832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42087,7 +42087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42342,7 +42342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42597,7 +42597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42852,7 +42852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43107,7 +43107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43362,7 +43362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43617,7 +43617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43872,7 +43872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44127,7 +44127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44382,7 +44382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44637,7 +44637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44892,7 +44892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45147,7 +45147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45402,7 +45402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45657,7 +45657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45912,7 +45912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46167,7 +46167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46422,7 +46422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46677,7 +46677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46932,7 +46932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47187,7 +47187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47442,7 +47442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47697,7 +47697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47952,7 +47952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48207,7 +48207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48462,7 +48462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48717,7 +48717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48972,7 +48972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49227,7 +49227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49482,7 +49482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49737,7 +49737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49992,7 +49992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50247,7 +50247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50502,7 +50502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50757,7 +50757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51012,7 +51012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51267,7 +51267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51522,7 +51522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51777,7 +51777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52032,7 +52032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52287,7 +52287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52542,7 +52542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52797,7 +52797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53052,7 +53052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53307,7 +53307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53562,7 +53562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53817,7 +53817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54072,7 +54072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54327,7 +54327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54582,7 +54582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54837,7 +54837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55092,7 +55092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55347,7 +55347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55602,7 +55602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55857,7 +55857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56112,7 +56112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56367,7 +56367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56622,7 +56622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56877,7 +56877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57132,7 +57132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57387,7 +57387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57642,7 +57642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57897,7 +57897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58152,7 +58152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58407,7 +58407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58662,7 +58662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58917,7 +58917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59172,7 +59172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59427,7 +59427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59682,7 +59682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59937,7 +59937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60192,7 +60192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60447,7 +60447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60702,7 +60702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60957,7 +60957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61212,7 +61212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61467,7 +61467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61722,7 +61722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61977,7 +61977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62232,7 +62232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62487,7 +62487,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62742,7 +62742,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62997,7 +62997,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63252,7 +63252,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63507,7 +63507,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63762,7 +63762,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64017,7 +64017,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64272,7 +64272,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64527,7 +64527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64782,7 +64782,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65292,7 +65292,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65547,7 +65547,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65802,7 +65802,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66057,7 +66057,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66312,7 +66312,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66567,7 +66567,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66822,7 +66822,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67077,7 +67077,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67332,7 +67332,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67587,7 +67587,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67842,7 +67842,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68097,7 +68097,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68352,7 +68352,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68607,7 +68607,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68862,7 +68862,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69117,7 +69117,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69372,7 +69372,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69627,7 +69627,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69882,7 +69882,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70137,7 +70137,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70392,7 +70392,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70647,7 +70647,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70902,7 +70902,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71157,7 +71157,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71412,7 +71412,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71667,7 +71667,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71922,7 +71922,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72177,7 +72177,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72432,7 +72432,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72687,7 +72687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72942,7 +72942,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73197,7 +73197,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73452,7 +73452,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73707,7 +73707,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73962,7 +73962,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74217,7 +74217,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74472,7 +74472,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74727,7 +74727,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74982,7 +74982,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75237,7 +75237,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75492,7 +75492,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75747,7 +75747,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76002,7 +76002,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76257,7 +76257,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76512,7 +76512,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76767,7 +76767,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77022,7 +77022,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77277,7 +77277,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77532,7 +77532,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77787,7 +77787,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78042,7 +78042,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78297,7 +78297,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78552,7 +78552,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78807,7 +78807,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79062,7 +79062,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79317,7 +79317,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79572,7 +79572,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79827,7 +79827,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80082,7 +80082,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80337,7 +80337,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80592,7 +80592,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80847,7 +80847,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81102,7 +81102,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81357,7 +81357,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81612,7 +81612,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81867,7 +81867,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82122,7 +82122,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82377,7 +82377,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82632,7 +82632,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82887,7 +82887,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83142,7 +83142,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83397,7 +83397,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83652,7 +83652,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83907,7 +83907,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84162,7 +84162,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84417,7 +84417,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84672,7 +84672,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84927,7 +84927,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85182,7 +85182,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85437,7 +85437,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85692,7 +85692,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85947,7 +85947,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86202,7 +86202,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86457,7 +86457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86712,7 +86712,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86967,7 +86967,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87222,7 +87222,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87477,7 +87477,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87732,7 +87732,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87987,7 +87987,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88242,7 +88242,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88497,7 +88497,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88752,7 +88752,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89007,7 +89007,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89262,7 +89262,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89517,7 +89517,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89772,7 +89772,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90027,7 +90027,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90282,7 +90282,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90537,7 +90537,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90792,7 +90792,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91047,7 +91047,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91302,7 +91302,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91557,7 +91557,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91812,7 +91812,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92067,7 +92067,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92322,7 +92322,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92577,7 +92577,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92832,7 +92832,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93087,7 +93087,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93342,7 +93342,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93597,7 +93597,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93852,7 +93852,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94107,7 +94107,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94362,7 +94362,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94617,7 +94617,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94872,7 +94872,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95127,7 +95127,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95382,7 +95382,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95637,7 +95637,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95892,7 +95892,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96147,7 +96147,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96402,7 +96402,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96657,7 +96657,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96912,7 +96912,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97167,7 +97167,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97422,7 +97422,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97677,7 +97677,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97932,7 +97932,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98187,7 +98187,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98442,7 +98442,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98697,7 +98697,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98952,7 +98952,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99207,7 +99207,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99462,7 +99462,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99717,7 +99717,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99972,7 +99972,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100227,7 +100227,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100482,7 +100482,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100737,7 +100737,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100992,7 +100992,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101247,7 +101247,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101502,7 +101502,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101757,7 +101757,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102012,7 +102012,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102267,7 +102267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102522,7 +102522,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102777,7 +102777,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103032,7 +103032,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103287,7 +103287,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103542,7 +103542,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103797,7 +103797,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104052,7 +104052,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104307,7 +104307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104562,7 +104562,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104817,7 +104817,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105072,7 +105072,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105327,7 +105327,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105582,7 +105582,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105837,7 +105837,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106092,7 +106092,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106347,7 +106347,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106602,7 +106602,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106857,7 +106857,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107112,7 +107112,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107367,7 +107367,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107622,7 +107622,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107877,7 +107877,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108132,7 +108132,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108387,7 +108387,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108642,7 +108642,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108897,7 +108897,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109152,7 +109152,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109407,7 +109407,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109662,7 +109662,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109917,7 +109917,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110172,7 +110172,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110427,7 +110427,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110682,7 +110682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110937,7 +110937,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111192,7 +111192,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111447,7 +111447,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111702,7 +111702,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111957,7 +111957,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112212,7 +112212,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112467,7 +112467,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112722,7 +112722,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112977,7 +112977,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113232,7 +113232,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -259,7 +259,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -507,7 +507,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -687,7 +687,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -681,7 +681,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_I8II_BH_AI_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_I8II_BH_AI_SAV_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -264,7 +264,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -516,7 +516,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -768,7 +768,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1020,7 +1020,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1272,7 +1272,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_Aux_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_Aux_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_S_MX_B_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_S_MX_B_Bias_A_SAV.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -256,7 +256,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -506,7 +506,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -755,7 +755,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1005,7 +1005,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_BiasSrcD_GradB_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_BiasSrcD_GradB_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_DB_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -259,7 +259,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -507,7 +507,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1537,7 +1537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1537,7 +1537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1537,7 +1537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1537,7 +1537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1791,7 +1791,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2045,7 +2045,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2299,7 +2299,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2553,7 +2553,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -2807,7 +2807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3061,7 +3061,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3315,7 +3315,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3569,7 +3569,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -3823,7 +3823,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4077,7 +4077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4331,7 +4331,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4585,7 +4585,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -4839,7 +4839,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5093,7 +5093,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5347,7 +5347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5601,7 +5601,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -5855,7 +5855,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6109,7 +6109,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6363,7 +6363,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6617,7 +6617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -6871,7 +6871,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7125,7 +7125,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7379,7 +7379,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7633,7 +7633,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -7887,7 +7887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8141,7 +8141,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8395,7 +8395,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8649,7 +8649,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -8903,7 +8903,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9157,7 +9157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9411,7 +9411,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9665,7 +9665,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -9919,7 +9919,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10173,7 +10173,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10427,7 +10427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10681,7 +10681,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -10935,7 +10935,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11189,7 +11189,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11443,7 +11443,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11697,7 +11697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -11951,7 +11951,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12205,7 +12205,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12459,7 +12459,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12713,7 +12713,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -12967,7 +12967,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13221,7 +13221,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13475,7 +13475,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13729,7 +13729,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -13983,7 +13983,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14237,7 +14237,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14491,7 +14491,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14745,7 +14745,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -14999,7 +14999,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15253,7 +15253,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15507,7 +15507,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -15761,7 +15761,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16015,7 +16015,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16269,7 +16269,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16523,7 +16523,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -16777,7 +16777,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17031,7 +17031,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17285,7 +17285,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17539,7 +17539,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -17793,7 +17793,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18047,7 +18047,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18301,7 +18301,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18555,7 +18555,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -18809,7 +18809,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19063,7 +19063,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19317,7 +19317,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19571,7 +19571,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -19825,7 +19825,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20079,7 +20079,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20333,7 +20333,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20587,7 +20587,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -20841,7 +20841,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21095,7 +21095,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21349,7 +21349,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21603,7 +21603,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -21857,7 +21857,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22111,7 +22111,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22365,7 +22365,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22619,7 +22619,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -22873,7 +22873,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23127,7 +23127,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23381,7 +23381,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23635,7 +23635,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -23889,7 +23889,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24143,7 +24143,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24397,7 +24397,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24651,7 +24651,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -24905,7 +24905,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25159,7 +25159,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25413,7 +25413,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25667,7 +25667,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -25921,7 +25921,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26175,7 +26175,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26429,7 +26429,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26683,7 +26683,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -26937,7 +26937,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27191,7 +27191,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27445,7 +27445,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27699,7 +27699,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -27953,7 +27953,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28207,7 +28207,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28461,7 +28461,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28715,7 +28715,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -28969,7 +28969,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29223,7 +29223,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29477,7 +29477,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29731,7 +29731,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -29985,7 +29985,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30239,7 +30239,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30493,7 +30493,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -30747,7 +30747,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31001,7 +31001,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31255,7 +31255,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31509,7 +31509,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -31763,7 +31763,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32017,7 +32017,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32271,7 +32271,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32525,7 +32525,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -32779,7 +32779,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33033,7 +33033,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33287,7 +33287,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33541,7 +33541,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -33795,7 +33795,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34049,7 +34049,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34303,7 +34303,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34557,7 +34557,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -34811,7 +34811,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35065,7 +35065,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35319,7 +35319,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35573,7 +35573,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -35827,7 +35827,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36081,7 +36081,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36335,7 +36335,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36589,7 +36589,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -36843,7 +36843,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37097,7 +37097,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37351,7 +37351,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37605,7 +37605,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -37859,7 +37859,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38113,7 +38113,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38367,7 +38367,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38621,7 +38621,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -38875,7 +38875,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39129,7 +39129,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39383,7 +39383,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39637,7 +39637,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -39891,7 +39891,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40145,7 +40145,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40399,7 +40399,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40653,7 +40653,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -40907,7 +40907,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41161,7 +41161,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41415,7 +41415,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41669,7 +41669,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -41923,7 +41923,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42177,7 +42177,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42431,7 +42431,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42685,7 +42685,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -42939,7 +42939,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43193,7 +43193,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43447,7 +43447,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43701,7 +43701,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -43955,7 +43955,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44209,7 +44209,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44463,7 +44463,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44717,7 +44717,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -44971,7 +44971,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45225,7 +45225,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45479,7 +45479,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45733,7 +45733,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -45987,7 +45987,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46241,7 +46241,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46495,7 +46495,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -46749,7 +46749,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47003,7 +47003,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47257,7 +47257,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47511,7 +47511,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -47765,7 +47765,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48019,7 +48019,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48273,7 +48273,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48527,7 +48527,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -48781,7 +48781,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49035,7 +49035,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49289,7 +49289,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49543,7 +49543,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -49797,7 +49797,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50051,7 +50051,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50305,7 +50305,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50559,7 +50559,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -50813,7 +50813,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51067,7 +51067,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51321,7 +51321,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51575,7 +51575,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -51829,7 +51829,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52083,7 +52083,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52337,7 +52337,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52591,7 +52591,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -52845,7 +52845,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53099,7 +53099,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53353,7 +53353,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53607,7 +53607,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -53861,7 +53861,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54115,7 +54115,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54369,7 +54369,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54623,7 +54623,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -54877,7 +54877,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55131,7 +55131,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55385,7 +55385,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55639,7 +55639,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -55893,7 +55893,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56147,7 +56147,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56401,7 +56401,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56655,7 +56655,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -56909,7 +56909,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57163,7 +57163,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57417,7 +57417,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57671,7 +57671,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -57925,7 +57925,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58179,7 +58179,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58433,7 +58433,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58687,7 +58687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -58941,7 +58941,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59195,7 +59195,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59449,7 +59449,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59703,7 +59703,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -59957,7 +59957,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60211,7 +60211,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60465,7 +60465,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60719,7 +60719,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -60973,7 +60973,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61227,7 +61227,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61481,7 +61481,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61735,7 +61735,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -61989,7 +61989,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62243,7 +62243,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62497,7 +62497,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -62751,7 +62751,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63005,7 +63005,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63259,7 +63259,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63513,7 +63513,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -63767,7 +63767,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64021,7 +64021,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64275,7 +64275,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64529,7 +64529,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -64783,7 +64783,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65037,7 +65037,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65291,7 +65291,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65545,7 +65545,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -65799,7 +65799,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66053,7 +66053,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66307,7 +66307,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66561,7 +66561,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -66815,7 +66815,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67069,7 +67069,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67323,7 +67323,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67577,7 +67577,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -67831,7 +67831,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68085,7 +68085,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68339,7 +68339,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68593,7 +68593,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -68847,7 +68847,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69101,7 +69101,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69355,7 +69355,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69609,7 +69609,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -69863,7 +69863,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70117,7 +70117,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70371,7 +70371,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70625,7 +70625,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -70879,7 +70879,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71133,7 +71133,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71387,7 +71387,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71641,7 +71641,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -71895,7 +71895,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72149,7 +72149,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72403,7 +72403,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72657,7 +72657,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -72911,7 +72911,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73165,7 +73165,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73419,7 +73419,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73673,7 +73673,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -73927,7 +73927,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74181,7 +74181,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74435,7 +74435,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74689,7 +74689,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -74943,7 +74943,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75197,7 +75197,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75451,7 +75451,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75705,7 +75705,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -75959,7 +75959,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76213,7 +76213,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76467,7 +76467,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76721,7 +76721,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -76975,7 +76975,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77229,7 +77229,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77483,7 +77483,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77737,7 +77737,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -77991,7 +77991,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78245,7 +78245,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78499,7 +78499,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -78753,7 +78753,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79007,7 +79007,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79261,7 +79261,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79515,7 +79515,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -79769,7 +79769,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80023,7 +80023,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80277,7 +80277,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80531,7 +80531,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -80785,7 +80785,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81039,7 +81039,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81293,7 +81293,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81547,7 +81547,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -81801,7 +81801,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82055,7 +82055,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82309,7 +82309,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82563,7 +82563,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -82817,7 +82817,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83071,7 +83071,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83325,7 +83325,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83579,7 +83579,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -83833,7 +83833,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84087,7 +84087,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84341,7 +84341,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84595,7 +84595,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -84849,7 +84849,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85103,7 +85103,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85357,7 +85357,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85611,7 +85611,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -85865,7 +85865,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86119,7 +86119,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86373,7 +86373,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86627,7 +86627,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -86881,7 +86881,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87135,7 +87135,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87389,7 +87389,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87643,7 +87643,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -87897,7 +87897,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88151,7 +88151,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88405,7 +88405,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88659,7 +88659,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -88913,7 +88913,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89167,7 +89167,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89421,7 +89421,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89675,7 +89675,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -89929,7 +89929,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90183,7 +90183,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90437,7 +90437,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90691,7 +90691,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -90945,7 +90945,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91199,7 +91199,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91453,7 +91453,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91707,7 +91707,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -91961,7 +91961,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92215,7 +92215,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92469,7 +92469,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92723,7 +92723,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -92977,7 +92977,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93231,7 +93231,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93485,7 +93485,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93739,7 +93739,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -93993,7 +93993,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94247,7 +94247,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94501,7 +94501,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -94755,7 +94755,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95009,7 +95009,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95263,7 +95263,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95517,7 +95517,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -95771,7 +95771,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96025,7 +96025,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96279,7 +96279,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96533,7 +96533,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -96787,7 +96787,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97041,7 +97041,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97295,7 +97295,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97549,7 +97549,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -97803,7 +97803,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98057,7 +98057,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98311,7 +98311,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98565,7 +98565,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -98819,7 +98819,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99073,7 +99073,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99327,7 +99327,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99581,7 +99581,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -99835,7 +99835,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100089,7 +100089,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100343,7 +100343,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100597,7 +100597,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -100851,7 +100851,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101105,7 +101105,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101359,7 +101359,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101613,7 +101613,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -101867,7 +101867,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102121,7 +102121,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102375,7 +102375,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102629,7 +102629,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -102883,7 +102883,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103137,7 +103137,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103391,7 +103391,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103645,7 +103645,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -103899,7 +103899,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104153,7 +104153,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104407,7 +104407,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104661,7 +104661,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -104915,7 +104915,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105169,7 +105169,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105423,7 +105423,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105677,7 +105677,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -105931,7 +105931,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106185,7 +106185,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106439,7 +106439,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106693,7 +106693,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -106947,7 +106947,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107201,7 +107201,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107455,7 +107455,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107709,7 +107709,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -107963,7 +107963,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108217,7 +108217,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108471,7 +108471,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108725,7 +108725,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -108979,7 +108979,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109233,7 +109233,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109487,7 +109487,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109741,7 +109741,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -109995,7 +109995,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110249,7 +110249,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110503,7 +110503,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -110757,7 +110757,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111011,7 +111011,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111265,7 +111265,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111519,7 +111519,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -111773,7 +111773,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112027,7 +112027,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112281,7 +112281,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112535,7 +112535,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -112789,7 +112789,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113043,7 +113043,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113297,7 +113297,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113551,7 +113551,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -113805,7 +113805,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114059,7 +114059,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114313,7 +114313,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114567,7 +114567,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -114821,7 +114821,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115075,7 +115075,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115329,7 +115329,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115583,7 +115583,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -115837,7 +115837,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116091,7 +116091,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116345,7 +116345,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116599,7 +116599,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -116853,7 +116853,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117107,7 +117107,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117361,7 +117361,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117615,7 +117615,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -117869,7 +117869,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118123,7 +118123,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118377,7 +118377,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118631,7 +118631,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -118885,7 +118885,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119139,7 +119139,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119393,7 +119393,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119647,7 +119647,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -119901,7 +119901,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120155,7 +120155,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120409,7 +120409,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120663,7 +120663,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -120917,7 +120917,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121171,7 +121171,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121425,7 +121425,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121679,7 +121679,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -121933,7 +121933,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122187,7 +122187,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122441,7 +122441,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122695,7 +122695,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -122949,7 +122949,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123203,7 +123203,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123457,7 +123457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123711,7 +123711,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -123965,7 +123965,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124219,7 +124219,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124473,7 +124473,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124727,7 +124727,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -124981,7 +124981,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125235,7 +125235,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125489,7 +125489,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125743,7 +125743,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -125997,7 +125997,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126251,7 +126251,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126505,7 +126505,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -126759,7 +126759,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127013,7 +127013,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127267,7 +127267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127521,7 +127521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -127775,7 +127775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -128029,7 +128029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -128283,7 +128283,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -128537,7 +128537,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -128791,7 +128791,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129045,7 +129045,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129299,7 +129299,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129553,7 +129553,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -129807,7 +129807,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130061,7 +130061,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130315,7 +130315,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130569,7 +130569,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -130823,7 +130823,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131077,7 +131077,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131331,7 +131331,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131585,7 +131585,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -131839,7 +131839,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132093,7 +132093,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132347,7 +132347,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132601,7 +132601,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -132855,7 +132855,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133109,7 +133109,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133363,7 +133363,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133617,7 +133617,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -133871,7 +133871,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134125,7 +134125,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134379,7 +134379,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134633,7 +134633,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -134887,7 +134887,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135141,7 +135141,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135395,7 +135395,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135649,7 +135649,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -135903,7 +135903,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136157,7 +136157,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136411,7 +136411,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136665,7 +136665,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -136919,7 +136919,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -137173,7 +137173,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -137427,7 +137427,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -137681,7 +137681,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -137935,7 +137935,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138189,7 +138189,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138443,7 +138443,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138697,7 +138697,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -138951,7 +138951,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139205,7 +139205,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139459,7 +139459,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -139713,7 +139713,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -687,7 +687,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -681,7 +681,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -681,7 +681,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_I8II_BH_AI_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_I8II_BH_AI_SAV_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -264,7 +264,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -516,7 +516,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -768,7 +768,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1020,7 +1020,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1272,7 +1272,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_Aux_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_Aux_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 0
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 0
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_A_SAV.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -256,7 +256,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -505,7 +505,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -754,7 +754,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1004,7 +1004,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_BBS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_BBS_BH_Bias_AH_SAV.yaml
@@ -52,7 +52,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_DB_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -259,7 +259,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -507,7 +507,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HHS_BH_Bias_AS_SAB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HHS_BH_Bias_AS_SAB_SAV.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HSS_BH_Bias_AS_SAB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8H_HSS_BH_Bias_AS_SAB_SAV.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_AH_SAV.yaml
@@ -52,7 +52,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -687,7 +687,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -681,7 +681,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_AH_SAV.yaml
@@ -52,7 +52,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_I8II_BH_AI_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_I8II_BH_AI_SAV_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: true
   TransposeB: true
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -264,7 +264,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -516,7 +516,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -768,7 +768,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1020,7 +1020,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_A_SAV.yaml
@@ -52,7 +52,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseInitialStridesAB: false
   UseInitialStridesCD: false
   UseScaleDVec: false
@@ -221,7 +221,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseInitialStridesAB: false
       UseInitialStridesCD: false
       UseScaleDVec: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_Aux_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_Aux_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 1
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 1
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_S_MX_B_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_S_MX_B_Bias_A_SAV.yaml
@@ -62,7 +62,7 @@
   TransposeA: true
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -256,7 +256,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -506,7 +506,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -755,7 +755,7 @@
       TransposeA: true
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1566,7 +1566,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8BS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8HS_BH_BiasSH_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8SS_BH_BiasSB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_AS_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_AS_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_DB_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -259,7 +259,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -507,7 +507,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8BS_BH_BiasB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8BS_BH_BiasB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1298,7 +1298,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1555,7 +1555,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8S_BH_BiasSHB_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8BS_BH_BiasB_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8BS_BH_BiasB_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -270,7 +270,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -527,7 +527,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -784,7 +784,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1041,7 +1041,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8F8S_BH_BiasSH_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -271,7 +271,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -530,7 +530,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -789,7 +789,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1048,7 +1048,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1307,7 +1307,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8HS_BH_BiasH_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HHS_BH_Bias_AS_SAB_SAV.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1029,7 +1029,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1283,7 +1283,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8H_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8SS_BH_BiasSB_AH_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -509,7 +509,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8SS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HF8S_BH_Bias_AS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HHS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -775,7 +775,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8_HSS_BH_Bias_AS_SAB_SAV_UserArgs.yaml
@@ -66,7 +66,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -267,7 +267,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -521,7 +521,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -687,7 +687,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -56,7 +56,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -233,7 +233,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -457,7 +457,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -682,7 +682,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -57,7 +57,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -235,7 +235,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -461,7 +461,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -264,7 +264,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -516,7 +516,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -768,7 +768,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1020,7 +1020,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_I8II_BH_AI_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_I8II_BH_AI_SAV_UserArgs.yaml
@@ -65,7 +65,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: false
+  UseBias: 0
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -264,7 +264,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -516,7 +516,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -768,7 +768,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1020,7 +1020,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1272,7 +1272,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: false
+      UseBias: 0
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_Aux_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_Aux_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
@@ -64,7 +64,7 @@
   TransposeA: 1
   TransposeB: 0
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: true
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -260,7 +260,7 @@
       TransposeA: 1
       TransposeB: 0
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: true
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_S_MX_B_Bias_A_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_S_MX_B_Bias_A_SAV.yaml
@@ -62,7 +62,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -256,7 +256,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -506,7 +506,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -755,7 +755,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -1005,7 +1005,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_BSS_BH_Bias_AH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_BSS_BH_Bias_AH.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_BSS_BH_Bias_AH_GB.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_BSS_BH_Bias_AH_GB.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_HSS_BH_Bias_AH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_HSS_BH_Bias_AH.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_HSS_BH_Bias_AH_GB.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_HSS_BH_Bias_AH_GB.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_BSS_BH_Bias_AH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_BSS_BH_Bias_AH.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_BSS_BH_Bias_AH_GB.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_BSS_BH_Bias_AH_GB.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_HSS_BH_Bias_AH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_HSS_BH_Bias_AH.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_HSS_BH_Bias_AH_GB.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_HSS_BH_Bias_AH_GB.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_BSS_BH_Bias_AH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_BSS_BH_Bias_AH.yaml
@@ -62,7 +62,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_BSS_BH_Bias_AH_GB.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_BSS_BH_Bias_AH_GB.yaml
@@ -62,7 +62,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_HSS_BH_Bias_AH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_HSS_BH_Bias_AH.yaml
@@ -62,7 +62,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_HSS_BH_Bias_AH_GB.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_HSS_BH_Bias_AH_GB.yaml
@@ -62,7 +62,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_BSS_BH_Bias_AH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_BSS_BH_Bias_AH.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_BSS_BH_Bias_AH_GB.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_BSS_BH_Bias_AH_GB.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_HSS_BH_Bias_AH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_HSS_BH_Bias_AH.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_HSS_BH_Bias_AH_GB.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_HSS_BH_Bias_AH_GB.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: true
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: false
       TransposeB: true
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_BSS_BH_Bias_AH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_BSS_BH_Bias_AH.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_BSS_BH_Bias_AH_GB.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_BSS_BH_Bias_AH_GB.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_HSS_BH_Bias_AH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_HSS_BH_Bias_AH.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_HSS_BH_Bias_AH_GB.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_HSS_BH_Bias_AH_GB.yaml
@@ -62,7 +62,7 @@
   TransposeA: false
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: false
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_BSS_BH_Bias_AH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_BSS_BH_Bias_AH.yaml
@@ -62,7 +62,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_BSS_BH_Bias_AH_GB.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_BSS_BH_Bias_AH_GB.yaml
@@ -62,7 +62,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_HSS_BH_Bias_AH.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_HSS_BH_Bias_AH.yaml
@@ -62,7 +62,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_HSS_BH_Bias_AH_GB.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_HSS_BH_Bias_AH_GB.yaml
@@ -62,7 +62,7 @@
   TransposeA: true
   TransposeB: false
   UseBeta: true
-  UseBias: true
+  UseBias: 1
   UseE: false
   UseInitialStridesAB: false
   UseInitialStridesCD: false
@@ -254,7 +254,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -499,7 +499,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -744,7 +744,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
@@ -989,7 +989,7 @@
       TransposeA: true
       TransposeB: false
       UseBeta: true
-      UseBias: true
+      UseBias: 1
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false

--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -480,11 +480,11 @@ namespace
             = (biasSrc == Tensile::ContractionProblemGemm::TENSOR::B) ? d.sizes()[1] : d.sizes()[0];
         if(a_type == Tensile::DataType::Int8 && b_type == Tensile::DataType::Int8)
         {
-            tensileProblem.setUseBias(false);
+            tensileProblem.setUseBias(0);
         }
         else
         {
-            tensileProblem.setUseBias(true);
+            tensileProblem.setUseBias(1);
             auto biasType = hipDataType_to_tensile_type(prob.bias_type);
             tensileProblem.setBias(biasType, biasSize, 0, prob.gradient, biasSrc);
             tensileProblem.setParams().setBiasEnum(
@@ -661,7 +661,7 @@ namespace
         if(fallback && prob.bias == nullptr && prob.scaleAlphaVec == nullptr && prob.E == nullptr
            && tensileAct == Tensile::ActivationType::None)
         {
-            tensileProblem.setUseBias(false);
+            tensileProblem.setUseBias(0);
             tensileProblem.setActivationType(Tensile::ActivationType::None);
             tensileProblem.setUseScaleAlphaVec(false);
             tensileProblem.setUseE(false);
@@ -681,11 +681,11 @@ namespace
                                                                                     : d.sizes()[0];
             if(a_type == Tensile::DataType::Int8 && b_type == Tensile::DataType::Int8)
             {
-                tensileProblem.setUseBias(false);
+                tensileProblem.setUseBias(0);
             }
             else
             {
-                tensileProblem.setUseBias(true);
+                tensileProblem.setUseBias(1);
                 auto biasType = hipDataType_to_tensile_type(prob.bias_type);
                 tensileProblem.setBias(biasType, biasSize, 0, prob.gradient, biasSrc);
                 tensileProblem.setParams().setBiasEnum(
@@ -1485,7 +1485,7 @@ rocblaslt_status makeArgument(rocblaslt_handle             handle,
             data->inputs.ws = workspace;
 
             // Backup and restore settings
-            bool                    useBias          = data->problem.useBias();
+            int                     useBias          = data->problem.useBias();
             Tensile::ActivationType actType          = data->problem.activationType();
             bool                    useScaleAlphaVec = data->problem.useScaleAlphaVec();
             bool                    useE             = data->problem.useE();
@@ -1906,7 +1906,7 @@ inline auto getSolutions(
         auto useE             = tensile_prob.useE();
         auto useScaleAB       = tensile_prob.useScaleAB();
         auto useScaleCD       = tensile_prob.useScaleCD();
-        tensile_prob.setUseBias(false);
+        tensile_prob.setUseBias(0);
         tensile_prob.setActivationType(Tensile::ActivationType::None);
         tensile_prob.setUseScaleAlphaVec(false);
         tensile_prob.setUseE(false);
@@ -2199,7 +2199,7 @@ rocblaslt_status isSolutionSupported(rocblaslt_handle            handle,
                 auto useE             = tensile_prob.useE();
                 auto useScaleAB       = tensile_prob.useScaleAB();
                 auto useScaleCD       = tensile_prob.useScaleCD();
-                tensile_prob.setUseBias(false);
+                tensile_prob.setUseBias(0);
                 tensile_prob.setActivationType(Tensile::ActivationType::None);
                 tensile_prob.setUseScaleAlphaVec(false);
                 tensile_prob.setUseE(false);
@@ -2326,7 +2326,7 @@ rocblaslt_status isSolutionSupported(rocblaslt_handle            handle,
                 auto actType          = tensile_prob.gemms[i].activationType();
                 auto useScaleAlphaVec = tensile_prob.gemms[i].useScaleAlphaVec();
                 auto useE             = tensile_prob.gemms[i].useE();
-                tensile_prob.gemms[i].setUseBias(false);
+                tensile_prob.gemms[i].setUseBias(0);
                 tensile_prob.gemms[i].setActivationType(Tensile::ActivationType::None);
                 tensile_prob.gemms[i].setUseScaleAlphaVec(false);
                 tensile_prob.gemms[i].setUseE(false);
@@ -2518,7 +2518,7 @@ rocblaslt_status getBestSolutions(rocblaslt_handle       handle,
                     useBias.push_back(data->problem.gemms[i].useBias());
                     actType.push_back(data->problem.gemms[i].activationType());
                     useScaleAlphaVec.push_back(data->problem.gemms[i].useScaleAlphaVec());
-                    data->problem.gemms[i].setUseBias(false);
+                    data->problem.gemms[i].setUseBias(0);
                     data->problem.gemms[i].setActivationType(Tensile::ActivationType::None);
                     data->problem.gemms[i].setUseScaleAlphaVec(false);
                 }

--- a/tensilelite/Tensile/AsmStoreState.py
+++ b/tensilelite/Tensile/AsmStoreState.py
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -274,7 +274,7 @@ class StoreState:
     #
     # Also create an AddrCalc for each memory operation.
     ##############################################################################
-    def setupStoreElementsForBatch(self, kernel, gwvw, batchElements, batchElementSgprs, isOptNLL):
+    def setupStoreElementsForBatch(self, kernel, gwvw, batchElements, batchElementSgprs, isOptNLL, biasDim):
 
         self.elementAddr     = []
         self.elementDataE    = []
@@ -459,13 +459,14 @@ class StoreState:
             self.elementData.append(data)
 
             if self.useBias == DataDirection.READ:
-                if coordOffset0 in biasVgprMap:
-                    dataBias = biasVgprMap[coordOffset0]
+                coordOffset = coordOffset0 if biasDim == 0 else coordOffset1
+                if coordOffset in biasVgprMap:
+                    dataBias = biasVgprMap[coordOffset]
                 else:
                     numVgprs = int(ceil(kernel["ProblemType"]["ComputeDataType"].numRegisters()))
                     dataBias = kw.vgprPool.checkOutAligned(int(numVgprs*self.cfg.gwvw), \
-                                  int(ceil(numVgprs*self.cfg.gwvw)), "bias data for ei=%u"%elementIdx, preventOverflow=False)
-                    biasVgprMap[coordOffset0] = dataBias
+                                int(ceil(numVgprs*self.cfg.gwvw)), "bias data for ei=%u"%elementIdx, preventOverflow=False)
+                    biasVgprMap[coordOffset] = dataBias
             else:
                 dataBias = 0
             self.elementDataBias.append(dataBias)

--- a/tensilelite/Tensile/BenchmarkProblems.py
+++ b/tensilelite/Tensile/BenchmarkProblems.py
@@ -106,7 +106,7 @@ def generateCustomKernelSolutions(problemType, customKernels, internalSupportPar
     return solutions
 
 def writeBenchmarkFiles(stepBaseDir, solutions, problemSizes, \
-        biasTypeArgs, activationArgs, stepName, solutionSummationSizes):
+        biasTypeArgs, biasDimArgs, activationArgs, stepName, solutionSummationSizes):
     """Write all the files needed for a given benchmarking step"""
     if not globalParameters["MergeFiles"]:
         ensurePath(os.path.join(globalParameters["WorkingPath"], "Solutions"))
@@ -178,10 +178,10 @@ def writeBenchmarkFiles(stepBaseDir, solutions, problemSizes, \
                 idealSize = {"Exact": [idealM, idealN, idealK]}
                 idealSizes.append(idealSize)
         idealProblemSizes = ProblemSizes(problemType, idealSizes)
-        writeClientConfig(True, solutions, idealProblemSizes, biasTypeArgs, activationArgs, stepName, stepBaseDir, \
+        writeClientConfig(True, solutions, idealProblemSizes, biasTypeArgs, biasDimArgs, activationArgs, stepName, stepBaseDir, \
             newLibrary, codeObjectFiles, True)
     else:
-        writeClientConfig(True, solutions, problemSizes, biasTypeArgs, activationArgs, stepName, stepBaseDir, \
+        writeClientConfig(True, solutions, problemSizes, biasTypeArgs, biasDimArgs, activationArgs, stepName, stepBaseDir, \
             newLibrary, codeObjectFiles, False)
 
     if len(solutions) == 0:
@@ -226,6 +226,7 @@ def benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSizeG
         elapsedTime = currentTime - startTime
         print1("# Benchmark Step: {} - {} {:.3f}s".format(groupName, stepName, elapsedTime))
         print1("# Num Sizes: {}".format(benchmarkStep.problemSizes.totalProblemSizes))
+        print1("# Bias Dim steps: {}".format(benchmarkStep.biasDimArgs.totalProblemSizes))
         print1("# Activation steps: {}".format(benchmarkStep.biasTypeArgs.totalProblemSizes))
         print1("# Activation steps: {}".format(benchmarkStep.activationArgs.totalProblemSizes))
         print1("# Fork Parameters:")
@@ -301,7 +302,7 @@ def benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSizeG
             prevCount = len(solutions)
             codeObjectFiles = writeBenchmarkFiles(stepBaseDir, solutions, \
                     benchmarkStep.problemSizes, benchmarkStep.biasTypeArgs, \
-                    benchmarkStep.activationArgs, shortName, [])
+                    benchmarkStep.biasDimArgs, benchmarkStep.activationArgs, shortName, [])
             # ^ this mutates solutions
 
             # write cache data

--- a/tensilelite/Tensile/BenchmarkStructs.py
+++ b/tensilelite/Tensile/BenchmarkStructs.py
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,8 @@ from .Common import print1, print2, hasParam, printExit, \
         defaultBenchmarkCommonParameters, validParameters, globalParameters, \
         defaultBatchedBenchmarkFinalProblemSizes, defaultBenchmarkFinalProblemSizes
 from .CustomKernels import getAllCustomKernelNames
-from .SolutionStructs import ProblemType, ProblemSizes, ActivationArgs, BiasTypeArgs
+from .SolutionStructs import ProblemType, ProblemSizes, ActivationArgs, BiasTypeArgs, \
+        BiasDimArgs
 
 
 def getDefaultsForMissingParameters(paramList, defaultParams):
@@ -155,6 +156,7 @@ class BenchmarkProcess:
 
         activationConf = ""
         biasTypesConf  = ""
+        biasDimConf  = ""
         if "BenchmarkFinalParameters" in config:
             sizes          = config["BenchmarkFinalParameters"][0]["ProblemSizes"]
             for bfp in config["BenchmarkFinalParameters"][1:]:
@@ -166,6 +168,10 @@ class BenchmarkProcess:
                   if biasTypesConf:
                     printExit("Duplicated BiasTypeArgs.")
                   biasTypesConf = bfp["BiasTypeArgs"]
+                if "BiasDimArgs" in bfp:
+                  if biasDimConf:
+                    printExit("Duplicated BiasDimArgs.")
+                  biasDimConf = bfp["BiasDimArgs"]
         else:
             sizes = defaultBatchedBenchmarkFinalProblemSizes if isbatched \
                 else defaultBenchmarkFinalProblemSizes
@@ -175,6 +181,7 @@ class BenchmarkProcess:
 
         self.biasTypesArgs  = BiasTypeArgs(self.problemType, biasTypesConf)
         self.activationArgs = ActivationArgs(self.problemType, activationConf)
+        self.biasDimArgs  = BiasDimArgs(self.problemType, biasDimConf)
 
         # validate parameter values
         configParams = {**benchmarkCommonParams, **forkParams}
@@ -225,6 +232,7 @@ class BenchmarkProcess:
                 self.internalSupportParams, \
                 self.problemSizes, \
                 self.biasTypesArgs, \
+                self.biasDimArgs, \
                 self.activationArgs, \
                 self.benchmarkStepIdx)
         self.benchmarkSteps.append(benchmarkStep)
@@ -286,7 +294,7 @@ def constructForkPermutations(forkParams, paramGroups):
 class BenchmarkStep:
     """A single benchmark step which consists of constant and fork parameters and a set of sizes"""
 
-    def __init__(self, forkParams, constantParams, paramGroups, customKernels, internalSupportParams, problemSizes, biasTypeArgs, activationArgs, idx):
+    def __init__(self, forkParams, constantParams, paramGroups, customKernels, internalSupportParams, problemSizes, biasTypeArgs, biasDimArgs, activationArgs, idx):
         """Basic constructor storing each argument"""
         self.forkParams = forkParams
         self.constantParams = constantParams
@@ -295,6 +303,7 @@ class BenchmarkStep:
         self.internalSupportParams = internalSupportParams
         self.problemSizes = problemSizes
         self.biasTypeArgs = biasTypeArgs
+        self.biasDimArgs = biasDimArgs
         self.activationArgs = activationArgs
         self.stepIdx = idx
 

--- a/tensilelite/Tensile/Common.py
+++ b/tensilelite/Tensile/Common.py
@@ -1137,7 +1137,7 @@ defaultProblemType = {
     "UseBeta":                  True,             # =True use beta parameter (asm will check for B=0 and optimize the write for that), =False don't use beta parameter
     "UseE":                     False,            # =True use output E to output gemm results before activation
     "Gradient":                 False,            # =True set globalWriteElements to gradient mode
-    "UseBias":                  False,            # =True use bias vector
+    "UseBias":                  0,                # =1 support bias vector on M direction, =2 support bias vector on N direction, =3 support bias vector on both M,N direction
     "BiasSrc":                  "D",              # This parameter is used in gradient + bias. Support A, B, D.
     "UseScaleAB":               False,            # =True use scaleA, scaleB
     "UseScaleCD":               False,            # =True use scaleC, scaleD

--- a/tensilelite/Tensile/Components/Signature.py
+++ b/tensilelite/Tensile/Components/Signature.py
@@ -213,6 +213,9 @@ class SignatureDefault(Signature):
             if writer.states.needBiasType:
                 signature.addArg("biasType",        SVK.SIG_VALUE,        "u32")
                 signature.addArg("StrideBias",      SVK.SIG_VALUE,        "u32")
+                if kernel["ProblemType"]["UseBias"] == 3:
+                    signature.addArg("biasDim",     SVK.SIG_VALUE,        "u32")
+                    userArgumentsInfo.biasSize += 4
         userArgumentsInfo.biasSize += (8 + 4 + 4)
 
         if kernel["ProblemType"]["UseE"]:

--- a/tensilelite/Tensile/Contractions.py
+++ b/tensilelite/Tensile/Contractions.py
@@ -190,10 +190,11 @@ class ProblemType:
         if 'UseBeta' in d:
             rv.useBeta = d['UseBeta']
 
-        rv.useBias               = False
+        rv.useBias               = 0
         rv.biasDataTypeWhiteList = []
         rv.biasSrcWhiteList = []
         rv.setConstStrideBias = []
+
         if 'UseBias' in d:
             rv.useBias = d['UseBias']
             if 'BiasDataTypeList' in d:

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname0_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname0_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname0_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname0_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname10_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname10_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname10_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname10_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname11_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname11_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname11_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname11_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname12_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname12_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname12_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname12_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname13_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname13_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname13_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname13_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname14_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname14_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname14_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname14_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname15_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname15_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname15_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname15_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname16_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname16_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname16_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname16_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname17_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname17_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname17_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname17_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname18_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname18_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname18_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname18_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname19_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname19_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname19_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname19_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname1_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname1_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname1_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname1_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname20_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname20_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname20_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname20_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname3_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname3_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname3_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname3_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname4_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname4_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname4_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname4_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname5_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname5_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname5_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname5_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname6_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname6_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname6_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname6_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname7_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname7_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname7_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname7_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname8_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname8_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname8_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname8_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname9_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname9_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname9_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname9_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname0_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname0_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname0_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname0_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname10_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname10_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname10_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname10_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname11_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname11_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname11_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname11_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname12_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname12_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname12_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname12_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname13_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname13_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname13_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname13_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname14_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname14_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname14_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname14_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname15_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname15_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname15_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname15_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname16_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname16_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname16_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname16_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname17_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname17_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname17_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname17_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname18_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname18_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname18_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname18_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname19_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname19_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname19_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname19_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname1_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname1_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname1_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname1_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname20_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname20_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname20_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname20_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname3_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname3_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname3_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname3_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname4_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname4_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname4_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname4_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname5_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname5_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname5_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname5_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname6_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname6_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname6_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname6_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname7_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname7_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname7_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname7_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname8_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname8_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname8_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname8_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname9_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname9_gfx941.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname9_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8H_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname9_gfx942.s
@@ -57,7 +57,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname0_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname0_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname0_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname0_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname10_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname10_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname10_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname10_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname11_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname11_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname11_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname11_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname12_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname12_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname12_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname12_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname13_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname13_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname13_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname13_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname14_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname14_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname14_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname14_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname15_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname15_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname15_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname15_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname16_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname16_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname16_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname16_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname17_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname17_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname17_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname17_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname18_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname18_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname18_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname18_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname1_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname1_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname1_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname1_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname2_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname2_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname2_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname2_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname3_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname3_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname3_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname3_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname4_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname4_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname4_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname4_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname5_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname5_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname5_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname5_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname6_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname6_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname6_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname6_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname7_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname7_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname7_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname7_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname8_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname8_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname8_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname8_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname9_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname9_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname9_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname9_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname0_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname0_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname0_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname0_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname10_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname10_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname10_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname10_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname11_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname11_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname11_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname11_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname12_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname12_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname12_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname12_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname13_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname13_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname13_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname13_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname14_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname14_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname14_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname14_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname15_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname15_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname15_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname15_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname16_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname16_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname16_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname16_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname17_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname17_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname17_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname17_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname18_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname18_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname18_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname18_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname1_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname1_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname1_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname1_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname2_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname2_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname2_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname2_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname3_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname3_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname3_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname3_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname4_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname4_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname4_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname4_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname5_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname5_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname5_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname5_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname6_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname6_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname6_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname6_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname7_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname7_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname7_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname7_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname8_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname8_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname8_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname8_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname9_gfx941.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname9_gfx941.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname9_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname9_gfx942.s
@@ -54,7 +54,7 @@ custom.config:
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
       UseBeta: True

--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -26,7 +26,8 @@ from . import Common
 from .TensileInstructions import Item, TensileInstructions, slash50, replaceHolder, \
                           KernelBody, Module, StructuredModule, TextBlock, Dump, LabelManager, \
                           RegisterPool, Assert, fastdeepcopy, TensileInstructionsPassOptions, \
-                          TensileInstructionsPass, getAsmCompileArgs, getAsmLinkCodeObjectArgs
+                          TensileInstructionsPass, getAsmCompileArgs, getAsmLinkCodeObjectArgs, \
+                          SLongBranchPositive, SBranch, SCBranchSCC0, SCBranchSCC1
 from .TensileInstructions.Instructions import *
 from .KernelWriterModules import *
 from .TensilePass import TensilePass, TensilePassOptions
@@ -230,6 +231,7 @@ class StateValues:
   numSgprAddressBias: int                = 0
   BiasType: int                          = 0
   BiasStride: int                        = 0
+  BiasDim: int                           = 0
 
   numReadsPerIterA: int                  = 0
   numReadsPerIterB: int                  = 0
@@ -1717,6 +1719,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
     # Close code is necessary for both first and last (NGLL case(=NLLfirst) needs label)
     module.add(self.closeSumAtLeastUnroll(kernel, tensorParametersA, tensorParametersB, prefetch=False, isOptNLL=isOptNLL, isNGLL=isNGLL))
 
+    if self.states.BiasDim == 3:
+      self.updateBranchPlaceHolder(module, ["skipOptNLL_placeholder", "skipOptNLL_scc1_placeholder"] , ["OptNLL_End", "OptNLL_End"], ["SCBranchSCC0", "SCBranchSCC1"])
     return module
 
   ##############################################################################
@@ -4631,3 +4635,51 @@ for codeObjectFileName in codeObjectFileNames:
 
   def setTensileInstructions(self, ti):
     self.ti = ti
+
+  def updateBranchPlaceHolder(self, module, placeholders, targets, operations):
+    phs = [ ph for ph in placeholders ]
+    found_phs = {}
+
+    def findInstByName(module, names, count):
+      for inst in module.items():
+        if isinstance(inst, Module):
+          if inst.name in phs:
+            found_phs[count] = inst
+            count += 1
+          else:
+            count = findInstByName(inst, names, count)
+        elif (not isinstance(inst, TextBlock)):
+          count += 1
+      return count
+
+    currentInstLength = findInstByName(module, phs, 0)
+    if len(found_phs) == 0:
+      return
+
+    for count in reversed(found_phs.keys()):
+      _placeholder = found_phs[count]
+      ph_idx = placeholders.index(_placeholder.name)
+
+      _target = Label(targets[ph_idx], "")
+      _operation = operations[ph_idx]
+
+      _placeholder.name = "Branch_%s"%_target.getLabelName()
+      if _operation == "SCBranchSCC0":
+        if currentInstLength - count + 1 >= 16384:
+          with self.allocTmpSgpr(3) as tmpSgprInfo:
+              _placeholder.add(self.longBranchScc0(_target, 1, tmpSgprInfo))
+        else:
+          _placeholder.add(SCBranchSCC0(labelName=_target.getLabelName()))
+      elif _operation == "SCBranchSCC1":
+        if currentInstLength - count + 1 >= 16384:
+          with self.allocTmpSgpr(3) as tmpSgprInfo:
+              _placeholder.add(self.longBranchScc1(_target, 1, tmpSgprInfo))
+        else:
+          _placeholder.add(SCBranchSCC1(labelName=_target.getLabelName()))
+      elif _operation == "SBranch":
+        if currentInstLength - count + 1 >= 16384:
+          with self.allocTmpSgpr(3) as tmpSgprInfo:
+            _placeholder.add(SLongBranchPositive(_target, tmpSgprInfo))
+        else:
+          _placeholder.add(SBranch(labelName=_target.getLabelName()))
+      currentInstLength += _placeholder.countType(Instruction)

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -484,7 +484,11 @@ class KernelWriterAssembly(KernelWriter):
         self.states.numStoreSgprNameSizes.append(self.states.BiasType)
         self.states.numStoreSgprNames.append("BiasStride")
         self.states.numStoreSgprNameSizes.append(self.states.BiasStride)
-      storeSgprLoad += self.states.numSgprAddressBias + self.states.BiasType + self.states.BiasStride
+        self.states.BiasDim = kernel["ProblemType"]["UseBias"]
+        if self.states.BiasDim == 3:
+          self.states.numStoreSgprNames.append("BiasDim")
+          self.states.numStoreSgprNameSizes.append(1)
+      storeSgprLoad += self.states.numSgprAddressBias + self.states.BiasType + self.states.BiasStride + (1 if self.states.BiasDim == 3 else 0)
     if kernel["ProblemType"]["UseE"]:
       storeSgprLoad += self.states.rpga + self.states.e.numSgprStrides
       self.states.numStoreSgprNames.append("AddressE")
@@ -4260,7 +4264,7 @@ class KernelWriterAssembly(KernelWriter):
           loadList.append([-1, 0, extArgOffset])  # Need to start a new loadAllKernArg cause the argument is not consecutively anymore.
         extArgOffset += self.states.userArgsInfo.biasSize
         if self.states.numSgprAddressBias:
-          biasLoadSize = (self.states.numSgprAddressBias + self.states.BiasType + self.states.BiasStride) * 4
+          biasLoadSize = (self.states.numSgprAddressBias + self.states.BiasType + self.states.BiasStride + (1 if self.states.BiasDim == 3 else 0)) * 4
           if loadList[-1][0] == -1:
             loadList[-1][0] = self.sgprs["AddressBias"]
           loadList[-1][1] += biasLoadSize
@@ -4797,7 +4801,8 @@ class KernelWriterAssembly(KernelWriter):
       skipOptNLL = Label("OptNLL_End", "")
       with self.allocTmpSgpr(4) as tmpSgprInfo:
         tmpSgpr = tmpSgprInfo.idx
-        module.add(self.checkIsBetaZero(kernel, tmpSgprInfo, skipOptNLL, isLongBranch=isLongBranch, posNeg=1))
+        placeHolder="skipOptNLL_placeholder" if self.states.BiasDim == 3 else None
+        module.add(self.checkIsBetaZero(kernel, tmpSgprInfo, skipOptNLL, isLongBranch=isLongBranch, placeHolder=placeHolder, posNeg=1))
 
         # check alpha
         if self.do["ApplyAlpha"]:
@@ -4834,18 +4839,29 @@ class KernelWriterAssembly(KernelWriter):
             module.add(SMovB32(dst=sgpr(tmpSgpr+0), src=hex(0x00000000), comment="lsb of real part of 1.0"))
             module.add(SMovB32(dst=sgpr(tmpSgpr+1), src=hex(0x3ff00000), comment="msb of real part of 1.0"))
             module.add(SCmpEQU64(src0=sgpr("Alpha",2), src1=sgpr(tmpSgpr,2), comment="Alpha.real == 1.0 ?"))
-            module.add(SCBranchSCC0(labelName=skipOptNLL.getLabelName(), comment="branch if alpha.real != 1"))
+            if placeHolder == None:
+              module.add(SCBranchSCC0(labelName=skipOptNLL.getLabelName(), comment="branch if alpha.real != 1"))
+            else:
+              skipOptNLLModule = Module("skipOptNLL_placeholder")
+              skipOptNLLModule.addComment1("branch if alpha.real != 1")
+              module.add(skipOptNLLModule)
             module.add(SMovB32(dst=sgpr(tmpSgpr+0), src=hex(0x00000000), comment="lsb of imag part of 0.0"))
             module.add(SMovB32(dst=sgpr(tmpSgpr+1), src=hex(0x00000000), comment="msb of imag part of 0.0"))
             module.add(SCmpEQU64(src0=sgpr("Alpha+2",2), src1=sgpr(tmpSgpr,2), comment="Alpha.imag == 0.0 ?"))
 
-          if isLongBranch:
-            module.add(self.longBranchScc0(skipOptNLL, posNeg=1, tmpSgprInfo=tmpSgprInfo, comment="branch if alpha != 1"))
+          if placeHolder == None:
+            if isLongBranch:
+              module.add(self.longBranchScc0(skipOptNLL, posNeg=1, tmpSgprInfo=tmpSgprInfo, comment="branch if alpha != 1"))
+            else:
+              module.add(SCBranchSCC0(labelName=skipOptNLL.getLabelName(), comment="branch if alpha != 1"))
           else:
-            module.add(SCBranchSCC0(labelName=skipOptNLL.getLabelName(), comment="branch if alpha != 1"))
+            skipOptNLLModule = Module("skipOptNLL_placeholder")
+            skipOptNLLModule.addComment1("branch if alpha != 1")
+            module.add(skipOptNLLModule)
           module.addSpaceLine()
 
-        module.add(self.checkIsEdge(kernel, tmpSgprInfo, skipOptNLL, isLongBranch=isLongBranch))
+        placeHolder = "skipOptNLL_scc1_placeholder" if self.states.BiasDim == 3 else None
+        module.add(self.checkIsEdge(kernel, tmpSgprInfo, skipOptNLL, isLongBranch=isLongBranch, placeHolder=placeHolder))
         module.addSpaceLine()
 
         # Check tail loop required:
@@ -4856,10 +4872,15 @@ class KernelWriterAssembly(KernelWriter):
           module.add(scalarStaticDivideAndRemainder(tmpSgpr, tmpSgpr+1, "SizesSum+%u"%self.states.unrollIdx, \
                     kernel["DepthU"], RegisterPoolResource(tmpSgpr+2, 2), 2))
           module.add(SCmpEQU32(src0=sgpr(tmpSgpr+1), src1=hex(0), comment="numIter%s == 0"%loopChar ))
-          if isLongBranch:
-            module.add(self.longBranchScc0(skipOptNLL, posNeg=1, tmpSgprInfo=tmpSgprInfo, comment="skip if tail loop required"))
+          if placeHolder == None:
+            if isLongBranch:
+              module.add(self.longBranchScc0(skipOptNLL, posNeg=1, tmpSgprInfo=tmpSgprInfo, comment="skip if tail loop required"))
+            else:
+              module.add(SCBranchSCC0(labelName=skipOptNLL.getLabelName(), comment="skip if tail loop required"))
           else:
-            module.add(SCBranchSCC0(labelName=skipOptNLL.getLabelName(), comment="skip if tail loop required"))
+            skipOptNLLModule = Module("skipOptNLL_placeholder")
+            skipOptNLLModule.addComment1("skip if tail loop required")
+            module.add(skipOptNLLModule)
 
       # save the vgprPool for generating the normal path.
       # dump the 'dirty' pool upon s_endpgm and swap back the 'clean' pool
@@ -6363,7 +6384,7 @@ class KernelWriterAssembly(KernelWriter):
                 numsOfRegister.append(blockWidth)
               if self.db["ForceInputValue%s"%tc]:
                 localWriteCVTCode.add(VMovB32(dst=vgpr("G2L%s+%u"%(tc, g2lIdx)), src=self.db["ForceValue%s"], comment="ForceInputValue"))
-              if (kernel["ProblemType"]["DataType"].isBFloat16() and kernel["ProblemType"]["DataType%s"%tc].isHalf()) and not tP["isM"]:            
+              if (kernel["ProblemType"]["DataType"].isBFloat16() and kernel["ProblemType"]["DataType%s"%tc].isHalf()) and not tP["isM"]:
                 numIters = 1 if blockWidth <= 1 else blockWidth
                 vgprTmp = self.vgprPool.checkOut(2)
                 for iter in range(0, numIters):
@@ -7834,7 +7855,7 @@ class KernelWriterAssembly(KernelWriter):
   # tmpSgpr is one temp sgpr
   # betaLabel is label to branch to if beta != 0
   ##############################################################################
-  def checkIsBetaZero(self, kernel, tmpSgprInfo, betaLabel, isLongBranch=False, posNeg: int=0):
+  def checkIsBetaZero(self, kernel, tmpSgprInfo, betaLabel, isLongBranch=False, placeHolder=None, posNeg: int=0):
     module = Module("checkIsBetaZero label %s"%betaLabel)
     assert(isinstance(betaLabel, Label))
     betaLabelName = betaLabel.getLabelName()
@@ -7846,10 +7867,14 @@ class KernelWriterAssembly(KernelWriter):
         for i in range(1, self.states.bpeCinternal//self.states.bpr):
           module.add(SOrB32(dst=sgpr(tmpSgprInfo.idx), src0=sgpr("Beta+%u"%i), src1=sgpr(tmpSgprInfo.idx), comment="tmp |= Beta[%u] " % i))
         module.add(SCmpKEQU32(src=sgpr(tmpSgprInfo.idx), simm16=hex(0), comment="Beta == 0"))
-      if isLongBranch:
-        module.add(self.longBranchScc0(betaLabel, posNeg, tmpSgprInfo))
+      if placeHolder == None:
+        if isLongBranch:
+          module.add(self.longBranchScc0(betaLabel, posNeg, tmpSgprInfo))
+        else:
+          module.add(SCBranchSCC0(labelName=betaLabelName, comment="Branch if Beta is not zero"))
       else:
-        module.add(SCBranchSCC0(labelName=betaLabelName, comment="Branch if Beta is not zero"))
+        placeHolderModule = Module(placeHolder)
+        module.add(placeHolderModule)
     module.addSpaceLine()
     return module
 
@@ -7858,7 +7883,7 @@ class KernelWriterAssembly(KernelWriter):
   # tmpSgpr must have at least 6 free SGPR
   # isEdgeTarget is the branch target if edges are required
   ##############################################################################
-  def checkIsEdge(self, kernel, tmpSgprInfo, isEdgeTarget, isLongBranch=False):
+  def checkIsEdge(self, kernel, tmpSgprInfo, isEdgeTarget, isLongBranch=False, placeHolder=None):
     assert(isinstance(isEdgeTarget, Label))
     isEdgeTargetLabel = isEdgeTarget.getLabelName()
     module = Module("checkIsEdge")
@@ -7893,10 +7918,15 @@ class KernelWriterAssembly(KernelWriter):
       module.add(SCmpKGtU32(src=sgpr(tmpS0), simm16=hex(0), comment="rMT0 > 0"))
       if self.db["ForceEdgeStores"]:
         module.add(SCmpEQU32(src0=sgpr(tmpS0), src1=sgpr(tmpS0), comment="ForceEdgeStores!"))
-      if isLongBranch:
-        module.add(self.longBranchScc1(isEdgeTarget, posNeg=1, tmpSgprInfo=tmpSgprInfo, comment="jump if edges required"))
+      if placeHolder == None:
+        if isLongBranch:
+          module.add(self.longBranchScc1(isEdgeTarget, posNeg=1, tmpSgprInfo=tmpSgprInfo, comment="jump if edges required"))
+        else:
+          module.add(SCBranchSCC1(labelName=isEdgeTargetLabel, comment="jump if edges required"))
       else:
-        module.add(SCBranchSCC1(labelName=isEdgeTargetLabel, comment="jump if edges required"))
+        placeHolderModule = Module(placeHolder)
+        placeHolderModule.addComment1("jump if edges required")
+        module.add(placeHolderModule)
 
     # check edge1 ###
     # TODO-packed - this only needs to change to handle packing into C1 index
@@ -7916,11 +7946,39 @@ class KernelWriterAssembly(KernelWriter):
     # if rMT1 > 0 goto label_B?_E1
     if self.do["EdgeWrite"]:
       module.add(SCmpKGtU32(src=sgpr(tmpS0), simm16=hex(0), comment="rMT1 > 0"))
-      if isLongBranch:
-        module.add(self.longBranchScc1(isEdgeTarget, posNeg=1, tmpSgprInfo=tmpSgprInfo, comment="jump if edges required"))
+      if placeHolder == None:
+        if isLongBranch:
+          module.add(self.longBranchScc1(isEdgeTarget, posNeg=1, tmpSgprInfo=tmpSgprInfo, comment="jump if edges required"))
+        else:
+          module.add(SCBranchSCC1(labelName=isEdgeTargetLabel, comment="jump if edges required"))
       else:
-        module.add(SCBranchSCC1(labelName=isEdgeTargetLabel, comment="jump if edges required"))
+        placeHolderModule = Module(placeHolder)
+        placeHolderModule.addComment1("jump if edges required")
+        module.add(placeHolderModule)
+    return module
 
+  ##############################################################################
+  # checkIsBiasDimZero
+  # tmpSgpr is one temp sgpr
+  # biasDimLabel is label to branch to if biasDim != 0
+  ##############################################################################
+  def checkIsBiasDimZero(self, kernel, tmpSgprInfo, biasDimLabel, isLongBranch=False, posNeg: int=0):
+    module = Module("checkIsBiasDimZero label %s"%biasDimLabel)
+    assert(isinstance(biasDimLabel, Label))
+    biasDimLabelName = biasDimLabel.getLabelName()
+    if kernel["ProblemType"]["UseBias"]:
+      if self.states.bpeCinternal <= self.states.bpr: # 1 register to check for Beta==0
+        module.add(SCmpKEQU32(src=sgpr("BiasDim"), simm16=hex(0), comment="BiasDim == 0"))
+      else: # multiple registers to check for Beta==0
+        module.add(SMovB32(dst=sgpr(tmpSgprInfo.idx), src=sgpr("BiasDim+0"), comment="tmp = BiasDim[0]"))
+        for i in range(1, self.states.bpeCinternal//self.states.bpr):
+          module.add(SOrB32(dst=sgpr(tmpSgprInfo.idx), src0=sgpr("BiasDim+%u"%i), src1=sgpr(tmpSgprInfo.idx), comment="tmp |= BiasDim[%u] " % i))
+        module.add(SCmpKEQU32(src=sgpr(tmpSgprInfo.idx), simm16=hex(0), comment="BiasDim == 0"))
+      if isLongBranch:
+        module.add(self.longBranchScc0(biasDimLabel, posNeg, tmpSgprInfo))
+      else:
+        module.add(SCBranchSCC0(labelName=biasDimLabelName, comment="Branch if BiasDim is not zero"))
+    module.addSpaceLine()
     return module
 
   ##############################################################################
@@ -7954,7 +8012,8 @@ class KernelWriterAssembly(KernelWriter):
                           noGSUBranch=False,
                           applyAlpha=True, # defaults to generating *=alpha codes
                           betas=None, # if left unspecified, then let global parameter decide
-                          edges=None):
+                          edges=None,
+                          biasDims=None):
     if not self.do["PostLoop"]: return Module("GlobalWriteElements (Empty)")
     module = Module("GlobalWriteElements")
     module.addComment2("Global Write Elements")
@@ -7968,6 +8027,7 @@ class KernelWriterAssembly(KernelWriter):
     useBiasBackup      = self.states.useBias
     betasBackup    = betas
     edgesBackup    = edges
+    biasDimsBackup = biasDims
     gsuLimit = 1 if noGSUBranch or globalParameters["SplitGSU"] else 2
     if gsuLimit > 1:
       gsuLabel = Label(label=self.labels.getNameInc("GSU"), comment="")
@@ -7977,6 +8037,7 @@ class KernelWriterAssembly(KernelWriter):
       if gsuLimit > 1:
         betas = betasBackup
         edges = edgesBackup
+        biasDims = biasDimsBackup
         if gsuLimitIdx == 0:
           self.states.bpeCexternal = self.states.bpeCinternal
           self.states.useBias = self.states.useBias if self.states.useBias == DataDirection.WRITE else DataDirection.NONE
@@ -8053,32 +8114,63 @@ class KernelWriterAssembly(KernelWriter):
         # Init bias Srd
         labelStr = self.labels.getNameInc("Bias")
         with self.allocTmpSgpr(1,1) as tmpSgprRes:
+          set_bs_label = Label(self.labels.getNameInc("Dont_Set_BiasStride"), "")
           tmpSgpr = tmpSgprRes.idx
           module.add(SAddU32(dst=sgpr(tmpSgpr), src0=sgpr("WorkGroup2"), src1=hex(1)))
           module.add(SMulI32(dst=sgpr(tmpSgpr), src0=sgpr("BiasStride"), src1=sgpr(tmpSgpr), comment="stride * (wg+1)"))
           module.add(SCmpEQU32(sgpr(tmpSgpr), hex(0), comment="bias stride = 0?"))
-          module.add(SCSelectB32(dst=sgpr(tmpSgpr), src0=sgpr("SizeI"), src1=sgpr(tmpSgpr)))
-          module.add(allocPostLoopSrdSuppress("Bias", labelStr, sgprLength=sgpr(tmpSgpr)))
-        multiBiasTypeLabel = []
-        for i in kernel["ProblemType"]["BiasDataTypeList"]:
-          name = self.labels.getNameInc("Load_Bias%s"%i.toNameAbbrev())
-          multiBiasTypeLabel.append(Label(name, ""))
-        loadBiasEndLabel = Label(self.labels.getNameInc("Load_Bias_End"), "")
-        multiBiasTypeLabel.append(loadBiasEndLabel)
-        offsetVgpr  = self.vgprPool.checkOut(1, 1)
-        with self.allocTmpSgpr(1, 1) as tmpSgprRes:
-          if len(kernel["ProblemType"]["BiasDataTypeList"]) == 1:
-            module.add(self.readBiasToLDS(kernel["ProblemType"]["BiasDataTypeList"][0], kernel, 1, offsetVgpr, tmpSgprRes.idx, tmpVgprRes))
+          if self.states.BiasDim == 3:
+            module.add(SCBranchSCC0(set_bs_label.getLabelName()))
+            module.add(SCmpKEQU32(src=sgpr("BiasDim"), simm16=hex(0), comment="BiasDim == 0"))
+            module.add(SCSelectB32(dst=sgpr(tmpSgpr), src0=sgpr("SizeI"), src1=sgpr("SizeJ")))
+            module.add(set_bs_label)
+          elif self.states.BiasDim == 2:
+            module.add(SCSelectB32(dst=sgpr(tmpSgpr), src0=sgpr("SizeJ"), src1=sgpr(tmpSgpr)))
           else:
-            for i, label in enumerate(multiBiasTypeLabel[1:]):
-              typeValue = kernel["ProblemType"]["BiasDataTypeList"][i].value
-              module.add(multiBiasTypeLabel[i])
-              module.add(SCmpKLGU32(sgpr("BiasType"), typeValue, "BiasType != %u"%typeValue))
-              module.add(SCBranchSCC1(label.getLabelName(), "Branch if true"))
-              module.add(self.readBiasToLDS(kernel["ProblemType"]["BiasDataTypeList"][i], kernel, 1, offsetVgpr, tmpSgprRes.idx, tmpVgprRes))
-              module.add(SBranch(labelName=loadBiasEndLabel.getLabelName(), comment="Branch to load bias end"))
-            module.add(loadBiasEndLabel)
-        self.vgprPool.checkIn(offsetVgpr)
+            module.add(SCSelectB32(dst=sgpr(tmpSgpr), src0=sgpr("SizeI"), src1=sgpr(tmpSgpr)))
+          module.add(allocPostLoopSrdSuppress("Bias", labelStr, sgprLength=sgpr(tmpSgpr)))
+
+        name = self.labels.getNameInc("Load_BiasDim_%u"%(0))
+        biasDim0Label = Label(self.labels.getNameInc("Load_BiasDim_0"), "")
+        biasDim1Label = Label(self.labels.getNameInc("Load_BiasDim_1"), "")
+        loadBiasEndLabel = Label(self.labels.getNameInc("Load_Bias_End"), "")
+        biasDims = [0]
+        if self.states.BiasDim == 3:
+          module.add(biasDim0Label)
+          module.add(SCmpKLGU32(sgpr("BiasDim"), 0, "BiasDim != 0"))
+          module.add(SCBranchSCC1(biasDim1Label.getLabelName(), "Branch if true"))
+          biasDims.append(1)
+        elif self.states.BiasDim == 2:
+          biasDims = [1]
+
+        for d in range(len(biasDims)):
+          if d == 1:
+            module.add(biasDim1Label)
+          multiBiasTypeLabel = []
+          for i in kernel["ProblemType"]["BiasDataTypeList"]:
+            name = self.labels.getNameInc("Load_Bias%s_%u"%(i.toNameAbbrev(), biasDims[d]))
+            multiBiasTypeLabel.append(Label(name, ""))
+          multiBiasTypeLabel.append(loadBiasEndLabel)
+          offsetVgpr  = self.vgprPool.checkOut(1, 1)
+          with self.allocTmpSgpr(1, 1) as tmpSgprRes:
+            if len(kernel["ProblemType"]["BiasDataTypeList"]) == 1:
+              module.add(self.readBiasToLDS(kernel["ProblemType"]["BiasDataTypeList"][0], kernel, 1, offsetVgpr, tmpSgprRes.idx, tmpVgprRes, biasDims[d]))
+              if len(biasDims) == 2:
+                if d == 0:
+                  module.add(SBranch(labelName=loadBiasEndLabel.getLabelName(), comment="Branch to load bias end"))
+                else:
+                  module.add(loadBiasEndLabel)
+            else:
+              for i, label in enumerate(multiBiasTypeLabel[1:]):
+                typeValue = kernel["ProblemType"]["BiasDataTypeList"][i].value
+                module.add(multiBiasTypeLabel[i])
+                module.add(SCmpKLGU32(sgpr("BiasType"), typeValue, "BiasType != %u"%typeValue))
+                module.add(SCBranchSCC1(label.getLabelName(), "Branch if true"))
+                module.add(self.readBiasToLDS(kernel["ProblemType"]["BiasDataTypeList"][i], kernel, 1, offsetVgpr, tmpSgprRes.idx, tmpVgprRes,  biasDims[d]))
+                module.add(SBranch(labelName=loadBiasEndLabel.getLabelName(), comment="Branch to load bias end"))
+              if d == len(biasDims) -1:
+                module.add(loadBiasEndLabel)
+          self.vgprPool.checkIn(offsetVgpr)
         self.vgprPool.checkIn(tmpVgpr)
       elif self.states.useBias == DataDirection.WRITE:
         labelStr = self.labels.getNameInc("Bias")
@@ -8200,31 +8292,54 @@ class KernelWriterAssembly(KernelWriter):
         betas = [False, True] if hasBeta else [False]
       if edges is None:
         edges = [False, True] if self.do["EdgeWrite"] else [False]
+      if biasDims is None:
+        biasDims = [0, 1] if self.states.BiasDim == 3 else [1] if self.states.BiasDim == 2 else [0]
       writeLabels = {}
       for beta in betas:
         writeLabels[beta] = {}
         for edge in edges:
           writeLabels[beta]["EdgeCheck0"] = Label(self.labels.getNameInc("GW_B%u_E%u_EdgeCheck0" % ( 1 if beta else 0, 1 if edge else 0) ), "")
           writeLabels[beta]["EdgeCheck1"] = Label(self.labels.getNameInc("GW_B%u_E%u_EdgeCheck1" % ( 1 if beta else 0, 1 if edge else 0) ), "")
-          writeLabels[beta][edge] = Label(self.labels.getNameInc("GW_B%u_E%u" % ( 1 if beta else 0, 1 if edge else 0) ), "")
+          writeLabels[beta][edge] = {}
+          if len(biasDims) == 1:
+             writeLabels[beta][edge][biasDims[0]] = Label(self.labels.getNameInc("GW_B%u_E%u" % ( 1 if beta else 0, 1 if edge else 0) ), "")
+          else:
+            for biasDim in biasDims:
+              writeLabels[beta][edge][biasDim] = Label(self.labels.getNameInc("GW_B%u_E%u_BD%u" % ( 1 if beta else 0, 1 if edge else 0, biasDim) ), "")
       endLabel = Label(self.labels.getNameInc("GW_End"), "")
 
       # Layout
       """
       if B1 goto label_B1
-      if E1 goto label_B0_E1
-      label_B0_E0:
+      if E1 goto label_B0_E1_BD0
+      if BD1 goto label_B0_E0_BD1
+      label_B0_E0_BD0:
       writes
       goto label_End
-      label_B0_E1:
+      label_B0_E0_BD1:
+      writes
+      goto label_End
+      label_B0_E1_BD0:
+      if BD1 goto label_B0_E1_BD1
+      writes
+      goto label_End
+      label_B0_E1_BD1:
       writes
       goto label_End
       label_B1:
-      if E1 goto label_B1_E1
-      label_B1_E0:
+      if E1 goto label_B1_E1_BD0
+      if BD1 goto label_B1_E0_BD1
+      label_B1_E0_BD0:
       writes
       goto label_End
-      label_B1_E1:
+      label_B1_E0_BD1:
+      writes
+      goto label_End
+      label_B1_E1_BD0:
+      if BD1 goto label_B1_E1_BD1
+      writes
+      goto label_End
+      label_B1_E1_BD1:
       writes
       goto label_End
       label_End
@@ -8323,279 +8438,38 @@ class KernelWriterAssembly(KernelWriter):
         # start B1
         if beta:
           betaModule.add(betaLabel)
-
         mod_pos = len(betaModule.items())
         # by now we either jumped to E1 or stayed at E0
         for idx1 in reversed(range(len(edges))):
           edge = edges[idx1]
           edgeModule = Module("edge_%u"%idx1)
-          edgeModule.add(writeLabels[beta][edge])
 
-          # for storeRemap edge case, non-beta still can enable vector stores
-          if kernel["StoreRemapVectorWidth"] and not beta:
-            edgeI = False
-          else:
-            edgeI = edge
-          #edgeI = True  # set to True to disable vector stores
-          gwvw = vectorWidths[edgeI]
+          edge_mode_pos = 0
+          for idx2 in range(len(biasDims)):
+            edge_mode_pos, currentInstLength, activationTypeStr = \
+                self.globalWriteElementBatch(kernel, tPA, tPB, activation,
+                                             applyAlpha, beta, edge, atomic,
+                                             vectorWidths, elements, activationLabelList,
+                                             tmpVgpr, cvtVgprStruct, activationSetPCStruct, activationEnumStrList,
+                                             actPCMaxTempSgpr, isInsertActFunctionCallAddrCalc, toActModuleList,
+                                             edgeModule, writeLabels, endLabel,
+                                             edge_mode_pos, currentInstLength,
+                                             idx0, idx1, idx2, biasDims)
+          if len(biasDims) == 2:
+           isLongBranch = True if currentInstLength >= 16384 else False
+           with self.allocTmpSgpr(3) as tmpSgprInfo:
+             checkIsBiasDimZero = edgeModule.add(self.checkIsBiasDimZero(kernel, tmpSgprInfo, \
+               writeLabels[beta][edge][biasDims[1]], isLongBranch=isLongBranch), pos=edge_mode_pos)
+             currentInstLength += checkIsBiasDimZero.countType(Instruction)
 
-          #print "globalWriteElements: edge=", edge, "beta=", beta, "atomic=", atomic
-
-          ########################################
-          # Calculate Vgprs for Write Batching
-          ########################################
-
-          ss = StoreState(self, kernel, gwvw, edge, beta, atomic, elements[edgeI])
-
-          # how many vgprs are needed for zero elements
-          # 2 for addressC in vgpr for addition - already checked out
-          # 2 for coord0,1 of thread - already checked out
-          # 2 for tmp - already checked out
-
-          # 5 = how many vgprs are needed per element (flat)
-          #  - 2 for addr
-          #  - 3 for GLOBAL_OFFSET_C calculation (can overlap below, therefore max)
-          #  - if beta gwvw*rpe for new value
-          #  - if atomic 2*rpe for old and cmp values
-
-          #print self.vgprPool.state()
-          # Use VGPR up to next occupancy threshold:
-          maxVgprs = self.getMaxRegsForOccupancy(kernel["NumThreads"], self.vgprPool.size(), \
-                                                self.getLdsSize(kernel), self.agprPool.size(), self.states.doubleVgpr)
-          if self.states.serializedStore: # get aggressive when serializedStore is on; not necessarily exclusive to this parameter
-            _growPool(self.vgprPool, self.vgprPool.size()-self.vgprPool.available(), maxVgprs, 1, \
-              "grow-pool up to next occupancy for GlobalWrite")
-          # Get numVgprAvailable
-          numVgprAvailable = self.vgprPool.availableBlock(ss.numVgprsPerElement, ss.align)
-
-          # Grow the register pool if needed - we need enough regs for at least one element
-          # Unfortunate since this means the write logic is setting the VGPR requirement
-          # for the entire kernel but at least we have a functional kernel.
-          # Before growing the pool, see if we can shrink the write vector width instead?
-          # TODO : the vgprSerial is needed for-ever and if we grow here will split the
-          # range of the tmps.  Maybe want to move vgprSerial to first vgpr?
-
-          # TODO: Minimum elems for StoreRemap
-          # TODO: Which of DataType or DestDataType is in a better sense? 0114: Check Using DestDataType + HSS
-          minElements = 2 if (kernel["ProblemType"]["DataType"].isHalf() or kernel["ProblemType"]["DataType"].isBFloat16()) else 1
-          minNeeded = minElements * ss.numVgprsPerElement
-          shrinkDb = 0
-          if shrinkDb:
-            print("numVgprAvailable=", numVgprAvailable, "minElements=", minElements, "minNeeded=", minNeeded)
-          if numVgprAvailable < minNeeded:
-            gwvwOrig = gwvw
-            currentOccupancy = self.getOccupancy(kernel["NumThreads"], self.getLdsSize(kernel), \
-                self.vgprPool.size(), self.agprPool.size(), self.states.doubleVgpr)
-            futureOccupancy = self.getOccupancy(kernel["NumThreads"], self.getLdsSize(kernel), \
-                self.vgprPool.size() - numVgprAvailable + minNeeded, self.agprPool.size(), self.states.doubleVgpr)
-
-            if shrinkDb:
-              print("currentOccupancy=%u futureOccupancy=%u VGPRs=%u numVgprAvail=%u vgprPerElem=%u" \
-                  % (currentOccupancy, futureOccupancy, self.vgprPool.size(), \
-                    numVgprAvailable, minElements*ss.numVgprsPerElement))
-            if futureOccupancy > currentOccupancy:
-              if shrinkDb:
-                print("warning: %s growing VGPR for GlobalWrite batching - this may bloat VGPR usage" % \
-                      (self.states.kernelName))
-                print("   numVgprAvailable=", numVgprAvailable, \
-                      "numVgprsPerElement=", ss.numVgprsPerElement, "atomic=", atomic, \
-                      "beta=", beta, "gwvw=", gwvw)
-            elif gwvw != gwvwOrig:
-              ss.cfg.gwvw = gwvw # make both representations consistent
-              if shrinkDb:
-                print2("info: %s shrank gwvw from %u to %u but kept occupancy same=%u." \
-                    % (self.states.kernelName, gwvwOrig, gwvw, currentOccupancy))
-
-            if numVgprAvailable < minElements*ss.numVgprsPerElement:
-              print2("info: growing pool += %d * %d for GlobalWrite\n" \
-                  % (minElements,ss.numVgprsPerElement))
-              print2(self.vgprPool.state())
-              _growPool(self.vgprPool, 0, minElements, ss.numVgprsPerElement, \
-                "grow-pool for GlobalWrite")
-              numVgprAvailable = self.vgprPool.available()
-              print2(self.vgprPool.state())
-
-          # set atomicW after we potentially resize GWVW
-          atomicW = min(gwvw, self.getVectorAtomicWidth(kernel))
-
-          # print("NumVgprAvailable", numVgprAvailable)
-          if ss.numVgprsPerElement:
-            numElementsPerBatch = numVgprAvailable // ss.numVgprsPerElement
-          else:
-            numElementsPerBatch = len(elements[edgeI]) # max, do 'em all
-
-          assert(self.states.c.numVgprValu % gwvw == 0) # sanity check
-
-          numElementsPerBatch = numElementsPerBatch if not kernel["NumElementsPerBatchStore"] else min(kernel["NumElementsPerBatchStore"],numElementsPerBatch)
-
-          if shrinkDb:
-            print("NumElementsPerBatch=", numElementsPerBatch, "LimitedBySgprs=", ss.cfg.numElementsPerBatchLimitedBySgprs, \
-                "WARNING" if ss.cfg.numElementsPerBatchLimitedBySgprs < numElementsPerBatch else "okay")
-          if ss.cfg.numElementsPerBatchLimitedBySgprs < numElementsPerBatch:
-            numElementsPerBatch = ss.cfg.numElementsPerBatchLimitedBySgprs
-
-          # TODO: Which of DataType or DestDataType is in a better sense? 0114: Check Using DestDataType + HSS
-          if (kernel["ProblemType"]["DataType"].isHalf() or kernel["ProblemType"]["DataType"].isBFloat16()):
-            # only do an even number of halves - since these share hi/lo pieces of some registers?
-            if numElementsPerBatch > 1:
-              numElementsPerBatch = int(numElementsPerBatch/2)*2
-            elif not kernel["EnableMatrixInstruction"]:
-              # The globalWriteBatch routine below can't handle odd elements per batch
-              # and 0 elements per batch is illegal.
-              # so if we don't have *GPR resources to handle a larger batch then need
-              # to mark overflowedResources rather than generate a kernel that won't work.
-              # It might be possible to fix globalWriteBatch to handle this case but these
-              # are likely to be low-performing so likely not worth optimizing.
-              if shrinkDb:
-                print("WARNING: half requires at least two elements per batch")
-              self.states.overflowedResources = 3
-
-          assert numElementsPerBatch > 0, "numElementsPerBatch=0 for %s"%self.states.kernelName
-
-          #numElementsPerBatch=min(2,numElementsPerBatch) # hack to control number of batches
-          if atomic and (ss.optSingleColVgpr or ss.optSharedColVgpr):
-            # hack to avoid re-using address vgpr across rows
-            # atomics need to perform several memory operations
-            # if the batch spans multiple rows, need multiple address vgpr
-            # which is not currently supported in the two opt*ColVgpr modes
-            firstRow = [e for e in elements[edgeI] if e[0]==0 and e[2]==0]
-            numElementsPerBatch=min(len(firstRow),numElementsPerBatch)
-
-          # check best numElementsPerBatch to handle a column block
-          # elements of column block must be multiple size of numElementsPerBatch
-          if kernel["StoreRemapVectorWidth"]:
-            firstRow = [e for e in elements[edgeI] if e[0]==0 and e[2]==0] # format for element = (tt1, tt0, vc1, vc0)
-            # find the largest factor and smaller than numElementPerBatch
-            nBatchesPerRow = 1
-            for d in range(1, len(firstRow)+1):
-              largestFactor = len(firstRow)//d
-              if len(firstRow)%d == 0 and largestFactor <= numElementsPerBatch:
-                numElementsPerBatch = largestFactor
-                nBatchesPerRow = d
-                break
-
-          # if no atomics and no edge, then write whole vectors
-          #if not atomic and not edge:
-          #  numVectorsPerBatch = numElementsPerBatch / kernel["GlobalWriteVectorWidth"]
-          #  #print "  NumVectorsPerBatch", numVectorsPerBatch
-          #  numElementsPerBatch = numVectorsPerBatch * kernel["GlobalWriteVectorWidth"]
-          numBatches = max(1, ceilDivide(len(elements[edgeI]),numElementsPerBatch))
-
-          numSgprs = ss.cfg.numTempSgprPerBatch + ss.cfg.numMaskSgprPerBatch + ss.cfg.numMaskSgprPerElement * numElementsPerBatch
-
-          if activationLabelList and isInsertActFunctionCallAddrCalc:
-            assert activationSetPCStruct, activationEnumStrList and activationLabelList and toActModuleList
-            numSgprs = max(actPCMaxTempSgpr, numSgprs)
-            edgeModule.add(self.insertActFunctionCallAddrCalc(activationSetPCStruct.sgprOffsetActivation, \
-              gwvw, toActModuleList, activationEnumStrList, activationLabelList, \
-              idx0, idx1))
-
-          if self.db["PrintStoreRegisterDb"]:
-            print("edgeI", edgeI, "NumBatches", numBatches, "NumElementsPerBatch", numElementsPerBatch, "numVgprsPerElement", ss.numVgprsPerElement, "len(elements[edgeI])", len(elements[edgeI]))
-            print ("numSgprs=", numSgprs, "sgprPool.size()=", self.sgprPool.size(), "numTempSgprPerBatch=", ss.cfg.numTempSgprPerBatch,
-                  "numMaskSgprPerBatch=", ss.cfg.numMaskSgprPerBatch, "numMaskSgprPerElement=", ss.cfg.numMaskSgprPerElement)
-            print(self.sgprPool.state())
-          edgeModule.addComment1("edge=%d, allocate %u sgpr. perBatchTmpS=%u perBatchMaskS=%u perElementMaskS=%u elementsPerBatch=%u" %
-              (edgeI, numSgprs, ss.cfg.numTempSgprPerBatch, ss.cfg.numMaskSgprPerBatch, ss.cfg.numMaskSgprPerElement, numElementsPerBatch))
-          #edgeModule.addComment("storeStats, %d, %d, %d"% (edgeI, numSgprs, numElementsPerBatch))
-          # so if we don't have *GPR resources to handle a larger batch then need
-          # to mark overflowedResources rather than generate a kernel that won't work.
-          # Activation
-          actLoopEndLabel, actLoopLabelModules, actLoopEnumStrList = self.initActivationLoop(kernel, beta, edge)
-          actLoopModuleList = []
-          actLoopModuleCodeLength = []
-          with self.allocTmpSgpr(numSgprs, 2) as tmpSgprRes:
-            for index, activationLabelModule in enumerate(actLoopLabelModules):
-              actLoopModule = Module("Activation Loop %s"%index)
-              activationTypeStr = actLoopEnumStrList[index]
-              if activationLabelModule:
-                actLoopModule.add(activationLabelModule)
-
-              tmpSgpr = tmpSgprRes.idx
-              actTempSgpr = tmpSgpr # Get sgpr start address, should always be the same
-              elementSgprs = tmpSgpr + ss.cfg.numTempSgprPerBatch
-              codeAccVgprRead = deepcopy(self.codes.accVgprRead) if self.states.serializedStore else None
-              mulAlpha = self.codes.mulAlphaMultipleBuffer if kernel["_GlobalAccumulation"] == 'MultipleBuffer' else self.codes.mulAlphaOther
-              codeMulAlpha = deepcopy(mulAlpha) if self.states.serializedStore else None
-
-              self.alphaBeforeLoadC = False
-              if kernel["MIArchVgpr"] and applyAlpha:
-                codeAccVgprRead = None
-
-                #Only apply when 2 wave optimization features are enabled
-                if (kernel["StorePriorityOpt"] or kernel["StoreSyncOpt"]) and beta:
-                  self.alphaBeforeLoadC = True
-              else:
-                codeMulAlpha = None
-
-              biasLocalBarrierInit = False
-              for batchIdx in range(0, numBatches):
-                elementStartIdx = batchIdx * numElementsPerBatch
-                elementStopIdx = min( elementStartIdx + numElementsPerBatch, len(elements[edgeI]) )
-                elementsThisBatch = elements[edgeI][elementStartIdx:elementStopIdx]
-                #print("BATCH[%u/%u]: elements[edgeI][%u:%u] VGPRs=%u" % (batchIdx, numBatches, elementStartIdx, elementStopIdx,ss.numVgprsPerElement ))
-                # elementVgprs can be large and should be perfectly tuned to the number of available
-                # VGPRS.  We do not want to accidentally overflow and grow the pool here:
-
-                if kernel["StoreRemapVectorWidth"]:
-                  #Indication if this batch is last batch for this column block shape
-                  self.StoreRemapLastBatch = 1 if (batchIdx+1) % nBatchesPerRow == 0 else 0
-
-                actLoopModule.add(self.globalWriteBatch(kernel, tPA, tPB, activation, ss, batchIdx, \
-                    applyAlpha, beta, edge, atomic, gwvw, atomicW, \
-                    elementsThisBatch, self.vgprs.addrE, self.vgprs.addrD, self.vgprs.addrC, self.vgprs.addrBias, self.vgprs.addrScaleAlphaVec, \
-                    biasLocalBarrierInit, tmpVgpr, cvtVgprStruct, activationSetPCStruct, \
-                    activationTypeStr, elementSgprs, tmpSgpr, codeAccVgprRead, codeMulAlpha))
-                biasLocalBarrierInit = True
-
-              ss.resetState()
-              actLoopModuleList.append(actLoopModule)
-              actLoopModuleCodeLength.append(actLoopModule.countType(Instruction))
-
-          if len(actLoopLabelModules) > 1:
-            actInstCounter = 0
-            # Add activation branch
-            for index, actLoopLabelModule in enumerate(actLoopLabelModules):
-              enumIndex = ActivationType.getEnumIndex(actLoopEnumStrList[index])
-              edgeModule.add(SCmpKEQU32(sgpr("ActivationType"), enumIndex, "activationType == %u"%enumIndex))
-              if actInstCounter >= 16384:
-                edgeModule.add(self.longBranchScc1(actLoopLabelModule, posNeg=1, comment="Branch if true"))
-              else:
-                edgeModule.add(SCBranchSCC1(actLoopLabelModule.getLabelName(), "Branch if true"))
-              actInstCounter += actLoopModuleCodeLength[index]
-            # Add jump to activation end
-            for index, _ in enumerate(actLoopLabelModules):
-              actLoopModule = actLoopModuleList[index]
-              if (index < (len(actLoopLabelModules) - 1)):
-                if actInstCounter >= 16384:
-                  with self.allocTmpSgpr(3) as tmpSgprInfo:
-                    actLoopModule.add(SLongBranchPositive(actLoopEndLabel, tmpSgprInfo))
-                else:
-                  actLoopModule.add(SBranch(labelName=actLoopEndLabel.getLabelName()))
-              actInstCounter -= actLoopModuleCodeLength[index]
-
-          # Append to edgeModule
-          for actLoopModule in actLoopModuleList:
-            edgeModule.appendModule(actLoopModule)
-          # Add actLoopEndLabel if needed
-          if len(actLoopLabelModules) > 1:
-            edgeModule.add(actLoopEndLabel)
-
-          if currentInstLength >= 16384:
-            with self.allocTmpSgpr(3) as tmpSgprInfo:
-              edgeModule.add(SLongBranchPositive(endLabel, tmpSgprInfo, comment="jump to end"))
-          else:
-            edgeModule.add(SBranch(labelName=endLabel.getLabelName(), comment="jump to end"))
-          currentInstLength += edgeModule.countType(Instruction)
           betaModule.add(edgeModule, pos=mod_pos)
-          del ss
         ########################################
         # branch if Edge0 or Edge1
         if False in edges and True in edges:
           isLongBranch = True if currentInstLength >= 16384 else False
           with self.allocTmpSgpr(4) as tmpSgprInfo:
             checkIsEdge = betaModule.add(self.checkIsEdge(kernel, tmpSgprInfo, \
-              writeLabels[beta][True], isLongBranch=isLongBranch), pos=mod_pos)
+              writeLabels[beta][True][biasDims[0]], isLongBranch=isLongBranch), pos=mod_pos)
             currentInstLength += checkIsEdge.countType(Instruction)
         betaModules.add(betaModule, pos=0)
 
@@ -8649,6 +8523,8 @@ class KernelWriterAssembly(KernelWriter):
 
       # End label
       module.add(endLabel)
+      if self.states.BiasDim == 3:
+        self.updateBranchPlaceHolder(module, ["end_placeholder"], [endLabel.label], ["SBranch"])
       self.vgprPool.checkIn(tmpVgpr)
       if cvtVgpr is not None:
         self.vgprPool.checkIn(cvtVgpr)
@@ -8659,6 +8535,286 @@ class KernelWriterAssembly(KernelWriter):
     kernel["_GlobalAccumulation"] = gsuAccumBackup
     self.states.bpeCexternal = bpeCexternalBackup
     return module
+
+  ##############################################################################
+  # globalWriteElementBatch :
+  ##############################################################################
+  def globalWriteElementBatch(self, kernel, tPA, tPB, activation, \
+                              applyAlpha, beta, edge, atomic, \
+                              vectorWidths, elements, activationLabelList, \
+                              tmpVgpr, cvtVgprStruct, activationSetPCStruct, activationEnumStrList, \
+                              actPCMaxTempSgpr, isInsertActFunctionCallAddrCalc, toActModuleList, \
+                              edgeModule, writeLabels, endLabel, \
+                              edge_mode_pos, currentInstLength, \
+                              idx0, idx1, idx2, biasDims):
+    biasDim = biasDims[idx2]
+    edgeModule.add(writeLabels[beta][edge][biasDim])
+    if idx2 == 0:
+      edge_mode_pos = len(edgeModule.items())
+
+    # for storeRemap edge case, non-beta still can enable vector stores
+    if kernel["StoreRemapVectorWidth"] and not beta:
+      edgeI = False
+    else:
+      edgeI = edge
+    #edgeI = True  # set to True to disable vector stores
+    gwvw = vectorWidths[edgeI]
+
+    #print "globalWriteElements: edge=", edge, "beta=", beta, "atomic=", atomic
+
+    ########################################
+    # Calculate Vgprs for Write Batching
+    ########################################
+
+    ss = StoreState(self, kernel, gwvw, edge, beta, atomic, elements[edgeI])
+
+    # how many vgprs are needed for zero elements
+    # 2 for addressC in vgpr for addition - already checked out
+    # 2 for coord0,1 of thread - already checked out
+    # 2 for tmp - already checked out
+
+    # 5 = how many vgprs are needed per element (flat)
+    #  - 2 for addr
+    #  - 3 for GLOBAL_OFFSET_C calculation (can overlap below, therefore max)
+    #  - if beta gwvw*rpe for new value
+    #  - if atomic 2*rpe for old and cmp values
+
+    #print self.vgprPool.state()
+    # Use VGPR up to next occupancy threshold:
+    maxVgprs = self.getMaxRegsForOccupancy(kernel["NumThreads"], self.vgprPool.size(), \
+                                          self.getLdsSize(kernel), self.agprPool.size(), self.states.doubleVgpr)
+    if self.states.serializedStore: # get aggressive when serializedStore is on; not necessarily exclusive to this parameter
+      _growPool(self.vgprPool, self.vgprPool.size()-self.vgprPool.available(), maxVgprs, 1, \
+        "grow-pool up to next occupancy for GlobalWrite")
+    # Get numVgprAvailable
+    numVgprAvailable = self.vgprPool.availableBlock(ss.numVgprsPerElement, ss.align)
+
+    # Grow the register pool if needed - we need enough regs for at least one element
+    # Unfortunate since this means the write logic is setting the VGPR requirement
+    # for the entire kernel but at least we have a functional kernel.
+    # Before growing the pool, see if we can shrink the write vector width instead?
+    # TODO : the vgprSerial is needed for-ever and if we grow here will split the
+    # range of the tmps.  Maybe want to move vgprSerial to first vgpr?
+
+    # TODO: Minimum elems for StoreRemap
+    # TODO: Which of DataType or DestDataType is in a better sense? 0114: Check Using DestDataType + HSS
+    minElements = 2 if (kernel["ProblemType"]["DataType"].isHalf() or kernel["ProblemType"]["DataType"].isBFloat16()) else 1
+    minNeeded = minElements * ss.numVgprsPerElement
+    shrinkDb = 0
+    if shrinkDb:
+      print("numVgprAvailable=", numVgprAvailable, "minElements=", minElements, "minNeeded=", minNeeded)
+    if numVgprAvailable < minNeeded:
+      gwvwOrig = gwvw
+      currentOccupancy = self.getOccupancy(kernel["NumThreads"], self.getLdsSize(kernel), \
+          self.vgprPool.size(), self.agprPool.size(), self.states.doubleVgpr)
+      futureOccupancy = self.getOccupancy(kernel["NumThreads"], self.getLdsSize(kernel), \
+          self.vgprPool.size() - numVgprAvailable + minNeeded, self.agprPool.size(), self.states.doubleVgpr)
+
+      if shrinkDb:
+        print("currentOccupancy=%u futureOccupancy=%u VGPRs=%u numVgprAvail=%u vgprPerElem=%u" \
+            % (currentOccupancy, futureOccupancy, self.vgprPool.size(), \
+              numVgprAvailable, minElements*ss.numVgprsPerElement))
+      if futureOccupancy > currentOccupancy:
+        if shrinkDb:
+          print("warning: %s growing VGPR for GlobalWrite batching - this may bloat VGPR usage" % \
+                (self.states.kernelName))
+          print("   numVgprAvailable=", numVgprAvailable, \
+                "numVgprsPerElement=", ss.numVgprsPerElement, "atomic=", atomic, \
+                "beta=", beta, "gwvw=", gwvw)
+      elif gwvw != gwvwOrig:
+        ss.cfg.gwvw = gwvw # make both representations consistent
+        if shrinkDb:
+          print2("info: %s shrank gwvw from %u to %u but kept occupancy same=%u." \
+              % (self.states.kernelName, gwvwOrig, gwvw, currentOccupancy))
+
+      if numVgprAvailable < minElements*ss.numVgprsPerElement:
+        print2("info: growing pool += %d * %d for GlobalWrite\n" \
+            % (minElements,ss.numVgprsPerElement))
+        print2(self.vgprPool.state())
+        _growPool(self.vgprPool, 0, minElements, ss.numVgprsPerElement, \
+          "grow-pool for GlobalWrite")
+        numVgprAvailable = self.vgprPool.available()
+        print2(self.vgprPool.state())
+
+    # set atomicW after we potentially resize GWVW
+    atomicW = min(gwvw, self.getVectorAtomicWidth(kernel))
+
+    # print("NumVgprAvailable", numVgprAvailable)
+    if ss.numVgprsPerElement:
+      numElementsPerBatch = numVgprAvailable // ss.numVgprsPerElement
+    else:
+      numElementsPerBatch = len(elements[edgeI]) # max, do 'em all
+
+    assert(self.states.c.numVgprValu % gwvw == 0) # sanity check
+
+    numElementsPerBatch = numElementsPerBatch if not kernel["NumElementsPerBatchStore"] else min(kernel["NumElementsPerBatchStore"],numElementsPerBatch)
+
+    if shrinkDb:
+      print("NumElementsPerBatch=", numElementsPerBatch, "LimitedBySgprs=", ss.cfg.numElementsPerBatchLimitedBySgprs, \
+          "WARNING" if ss.cfg.numElementsPerBatchLimitedBySgprs < numElementsPerBatch else "okay")
+    if ss.cfg.numElementsPerBatchLimitedBySgprs < numElementsPerBatch:
+      numElementsPerBatch = ss.cfg.numElementsPerBatchLimitedBySgprs
+
+    # TODO: Which of DataType or DestDataType is in a better sense? 0114: Check Using DestDataType + HSS
+    if (kernel["ProblemType"]["DataType"].isHalf() or kernel["ProblemType"]["DataType"].isBFloat16()):
+      # only do an even number of halves - since these share hi/lo pieces of some registers?
+      if numElementsPerBatch > 1:
+        numElementsPerBatch = int(numElementsPerBatch/2)*2
+      elif not kernel["EnableMatrixInstruction"]:
+        # The globalWriteBatch routine below can't handle odd elements per batch
+        # and 0 elements per batch is illegal.
+        # so if we don't have *GPR resources to handle a larger batch then need
+        # to mark overflowedResources rather than generate a kernel that won't work.
+        # It might be possible to fix globalWriteBatch to handle this case but these
+        # are likely to be low-performing so likely not worth optimizing.
+        if shrinkDb:
+          print("WARNING: half requires at least two elements per batch")
+        self.states.overflowedResources = 3
+
+    assert numElementsPerBatch > 0, "numElementsPerBatch=0 for %s"%self.states.kernelName
+
+    #numElementsPerBatch=min(2,numElementsPerBatch) # hack to control number of batches
+    if atomic and (ss.optSingleColVgpr or ss.optSharedColVgpr):
+      # hack to avoid re-using address vgpr across rows
+      # atomics need to perform several memory operations
+      # if the batch spans multiple rows, need multiple address vgpr
+      # which is not currently supported in the two opt*ColVgpr modes
+      firstRow = [e for e in elements[edgeI] if e[0]==0 and e[2]==0]
+      numElementsPerBatch=min(len(firstRow),numElementsPerBatch)
+
+    # check best numElementsPerBatch to handle a column block
+    # elements of column block must be multiple size of numElementsPerBatch
+    if kernel["StoreRemapVectorWidth"]:
+      firstRow = [e for e in elements[edgeI] if e[0]==0 and e[2]==0] # format for element = (tt1, tt0, vc1, vc0)
+      # find the largest factor and smaller than numElementPerBatch
+      nBatchesPerRow = 1
+      for d in range(1, len(firstRow)+1):
+        largestFactor = len(firstRow)//d
+        if len(firstRow)%d == 0 and largestFactor <= numElementsPerBatch:
+          numElementsPerBatch = largestFactor
+          nBatchesPerRow = d
+          break
+
+    # if no atomics and no edge, then write whole vectors
+    #if not atomic and not edge:
+    #  numVectorsPerBatch = numElementsPerBatch / kernel["GlobalWriteVectorWidth"]
+    #  #print "  NumVectorsPerBatch", numVectorsPerBatch
+    #  numElementsPerBatch = numVectorsPerBatch * kernel["GlobalWriteVectorWidth"]
+    numBatches = max(1, ceilDivide(len(elements[edgeI]),numElementsPerBatch))
+
+    numSgprs = ss.cfg.numTempSgprPerBatch + ss.cfg.numMaskSgprPerBatch + ss.cfg.numMaskSgprPerElement * numElementsPerBatch
+
+    if activationLabelList and isInsertActFunctionCallAddrCalc:
+      assert activationSetPCStruct, activationEnumStrList and activationLabelList and toActModuleList
+      numSgprs = max(actPCMaxTempSgpr, numSgprs)
+      edgeModule.add(self.insertActFunctionCallAddrCalc(activationSetPCStruct.sgprOffsetActivation, \
+        gwvw, toActModuleList, activationEnumStrList, activationLabelList, \
+        idx0, idx1))
+
+    if self.db["PrintStoreRegisterDb"]:
+      print("edgeI", edgeI, "NumBatches", numBatches, "NumElementsPerBatch", numElementsPerBatch, "numVgprsPerElement", ss.numVgprsPerElement, "len(elements[edgeI])", len(elements[edgeI]))
+      print ("numSgprs=", numSgprs, "sgprPool.size()=", self.sgprPool.size(), "numTempSgprPerBatch=", ss.cfg.numTempSgprPerBatch,
+            "numMaskSgprPerBatch=", ss.cfg.numMaskSgprPerBatch, "numMaskSgprPerElement=", ss.cfg.numMaskSgprPerElement)
+      print(self.sgprPool.state())
+    edgeModule.addComment1("edge=%d, allocate %u sgpr. perBatchTmpS=%u perBatchMaskS=%u perElementMaskS=%u elementsPerBatch=%u" %
+        (edgeI, numSgprs, ss.cfg.numTempSgprPerBatch, ss.cfg.numMaskSgprPerBatch, ss.cfg.numMaskSgprPerElement, numElementsPerBatch))
+    #edgeModule.addComment("storeStats, %d, %d, %d"% (edgeI, numSgprs, numElementsPerBatch))
+    # so if we don't have *GPR resources to handle a larger batch then need
+    # to mark overflowedResources rather than generate a kernel that won't work.
+    # Activation
+    actLoopEndLabel, actLoopLabelModules, actLoopEnumStrList = self.initActivationLoop(kernel, beta, edge)
+    actLoopModuleList = []
+    actLoopModuleCodeLength = []
+    with self.allocTmpSgpr(numSgprs, 2) as tmpSgprRes:
+      for index, activationLabelModule in enumerate(actLoopLabelModules):
+        actLoopModule = Module("Activation Loop %s"%index)
+        activationTypeStr = actLoopEnumStrList[index]
+        if activationLabelModule:
+          actLoopModule.add(activationLabelModule)
+
+        tmpSgpr = tmpSgprRes.idx
+        actTempSgpr = tmpSgpr # Get sgpr start address, should always be the same
+        elementSgprs = tmpSgpr + ss.cfg.numTempSgprPerBatch
+        codeAccVgprRead = deepcopy(self.codes.accVgprRead) if self.states.serializedStore else None
+        mulAlpha = self.codes.mulAlphaMultipleBuffer if kernel["_GlobalAccumulation"] == 'MultipleBuffer' else self.codes.mulAlphaOther
+        codeMulAlpha = deepcopy(mulAlpha) if self.states.serializedStore else None
+
+        self.alphaBeforeLoadC = False
+        if kernel["MIArchVgpr"] and applyAlpha:
+          codeAccVgprRead = None
+
+          #Only apply when 2 wave optimization features are enabled
+          if (kernel["StorePriorityOpt"] or kernel["StoreSyncOpt"]) and beta:
+            self.alphaBeforeLoadC = True
+        else:
+          codeMulAlpha = None
+
+        biasLocalBarrierInit = False
+        for batchIdx in range(0, numBatches):
+          elementStartIdx = batchIdx * numElementsPerBatch
+          elementStopIdx = min( elementStartIdx + numElementsPerBatch, len(elements[edgeI]) )
+          elementsThisBatch = elements[edgeI][elementStartIdx:elementStopIdx]
+          #print("BATCH[%u/%u]: elements[edgeI][%u:%u] VGPRs=%u" % (batchIdx, numBatches, elementStartIdx, elementStopIdx,ss.numVgprsPerElement ))
+          # elementVgprs can be large and should be perfectly tuned to the number of available
+          # VGPRS.  We do not want to accidentally overflow and grow the pool here:
+
+          if kernel["StoreRemapVectorWidth"]:
+            #Indication if this batch is last batch for this column block shape
+            self.StoreRemapLastBatch = 1 if (batchIdx+1) % nBatchesPerRow == 0 else 0
+
+          actLoopModule.add(self.globalWriteBatch(kernel, tPA, tPB, activation, ss, batchIdx, \
+              applyAlpha, beta, edge, atomic, gwvw, atomicW, \
+              elementsThisBatch, self.vgprs.addrE, self.vgprs.addrD, self.vgprs.addrC, self.vgprs.addrBias, self.vgprs.addrScaleAlphaVec, \
+              biasLocalBarrierInit, tmpVgpr, cvtVgprStruct, activationSetPCStruct, \
+              activationTypeStr, elementSgprs, tmpSgpr, codeAccVgprRead, codeMulAlpha, biasDim))
+          biasLocalBarrierInit = True
+
+        ss.resetState()
+        actLoopModuleList.append(actLoopModule)
+        actLoopModuleCodeLength.append(actLoopModule.countType(Instruction))
+
+    if len(actLoopLabelModules) > 1:
+      actInstCounter = 0
+      # Add activation branch
+      for index, actLoopLabelModule in enumerate(actLoopLabelModules):
+        enumIndex = ActivationType.getEnumIndex(actLoopEnumStrList[index])
+        edgeModule.add(SCmpKEQU32(sgpr("ActivationType"), enumIndex, "activationType == %u"%enumIndex))
+        if actInstCounter >= 16384:
+          edgeModule.add(self.longBranchScc1(actLoopLabelModule, posNeg=1, comment="Branch if true"))
+        else:
+          edgeModule.add(SCBranchSCC1(actLoopLabelModule.getLabelName(), "Branch if true"))
+        actInstCounter += actLoopModuleCodeLength[index]
+      # Add jump to activation end
+      for index, _ in enumerate(actLoopLabelModules):
+        actLoopModule = actLoopModuleList[index]
+        if (index < (len(actLoopLabelModules) - 1)):
+          if actInstCounter >= 16384:
+            with self.allocTmpSgpr(3) as tmpSgprInfo:
+              actLoopModule.add(SLongBranchPositive(actLoopEndLabel, tmpSgprInfo))
+          else:
+            actLoopModule.add(SBranch(labelName=actLoopEndLabel.getLabelName()))
+        actInstCounter -= actLoopModuleCodeLength[index]
+
+    # Append to edgeModule
+    for actLoopModule in actLoopModuleList:
+      edgeModule.appendModule(actLoopModule)
+    # Add actLoopEndLabel if needed
+    if len(actLoopLabelModules) > 1:
+      edgeModule.add(actLoopEndLabel)
+
+    if len(biasDims) == 1:
+      if currentInstLength >= 16384:
+        with self.allocTmpSgpr(3) as tmpSgprInfo:
+          edgeModule.add(SLongBranchPositive(endLabel, tmpSgprInfo, comment="jump to end"))
+      else:
+        edgeModule.add(SBranch(labelName=endLabel.getLabelName(), comment="jump to end"))
+    else:
+      end_placeholder = Module("end_placeholder")
+      edgeModule.add(end_placeholder)
+    currentInstLength += edgeModule.countType(Instruction)
+    del ss
+
+    return edge_mode_pos, currentInstLength, activationTypeStr
 
   ##############################################################################
   # chooseGlobalRead :
@@ -8895,13 +9051,13 @@ class KernelWriterAssembly(KernelWriter):
 
     return module
 
-  def addBiasLoad(self, dataType, kernel, ss, addrCalc, biasVgpr, isLocal=False):
+  def addBiasLoad(self, dataType, kernel, gwvw, addrCalc, biasVgpr, biasDim, isLocal=False):
     if isLocal and (self.states.useBias == DataDirection.READ):
       module = Module("addBias")
       dst = vgpr(biasVgpr)
       src = vgpr(addrCalc.addrBiasVgpr)
-      ds = DSModifiers(offset=addrCalc.biasOffset)
-      bpl = dataType.numBytes() * ss.cfg.gwvw
+      ds = DSModifiers(offset=addrCalc.biasOffset[biasDim])
+      bpl = dataType.numBytes() * gwvw
       if bpl==2:
         module.add(DSLoadU16(dst=dst, src=src, ds=ds, comment="load bias"))
       elif bpl==4:
@@ -8912,7 +9068,7 @@ class KernelWriterAssembly(KernelWriter):
         module.add(DSLoadB128(dst=vgpr(biasVgpr, 4), src=src, ds=ds, comment="load bias"))
       elif bpl==32:
         module.add(DSLoadB128(dst=vgpr(biasVgpr, 4), src=src, ds=ds, comment="load bias"))
-        ds = DSModifiers(offset=addrCalc.biasOffset+bpl/2)
+        ds = DSModifiers(offset=addrCalc.biasOffset[biasDim]+bpl/2)
         module.add(DSLoadB128(dst=vgpr(biasVgpr+4, 4), src=src, ds=ds, comment="load bias"))
       else:
         assert 0, "bad bpl"
@@ -8928,7 +9084,7 @@ class KernelWriterAssembly(KernelWriter):
     else:
       addr0 = ""
       addr1 = ""
-    return self.addBiasGlobalLoad(dataType, kernel, biasVgpr, addr0, addr1, addrCalc.biasOffset, ss.cfg.gwvw)
+    return self.addBiasGlobalLoad(dataType, kernel, biasVgpr, addr0, addr1, addrCalc.biasOffset[biasDim], gwvw)
 
   ##############################################################################
   def addStore(self, kernel, ss, tc: str, addrCalc, sumIdx, tmpS01, edge, comment):
@@ -9094,14 +9250,14 @@ class KernelWriterAssembly(KernelWriter):
       applyAlpha, beta, edge, atomic, gwvw, atomicW, \
       batchElements, addrE, addrD, addrC, addrBias, addrScaleAlphaVec, biasLocalBarrierInit: bool, \
       tmpVgpr, cvtVgprStruct, activationSetPCStruct, activationTypeStr, \
-      batchElementSgprs, tmpSgpr, codeAccVgprRead, codeMulAlpha) -> Module:
+      batchElementSgprs, tmpSgpr, codeAccVgprRead, codeMulAlpha, biasDim) -> Module:
       packdata = Component.PackData.find(self)
       gwriter  = Component.GlobalWriteComponents.find(self)
       return gwriter(kernel, tPA, tPB, activation, ss, \
         batchIdx, applyAlpha, beta, edge, atomic, gwvw, atomicW, \
         batchElements, addrE, addrD, addrC, addrBias, addrScaleAlphaVec, biasLocalBarrierInit, \
         tmpVgpr, cvtVgprStruct, activationSetPCStruct, activationTypeStr, \
-        batchElementSgprs, tmpSgpr, codeAccVgprRead, codeMulAlpha, packdata, self)
+        batchElementSgprs, tmpSgpr, codeAccVgprRead, codeMulAlpha, packdata, self, biasDim)
 
   ##############################################################################
   def openPrefetchGlobalRead2(self, kernel):
@@ -9121,7 +9277,7 @@ class KernelWriterAssembly(KernelWriter):
   ########################################
   # Bias related
   ########################################
-  def readBiasToLDS(self, biasDataType, kernel, gwvw, offsetVgpr, tmpSgpr, tmpVgpr1Res: RegisterPoolResource):
+  def readBiasToLDS(self, biasDataType, kernel, gwvw, offsetVgpr, tmpSgpr, tmpVgpr1Res: RegisterPoolResource, dim):
     assert gwvw == 1
     assert tmpVgpr1Res.size >= gwvw * kernel["ProblemType"]["ComputeDataType"].numRegisters()
     # Params
@@ -9131,10 +9287,10 @@ class KernelWriterAssembly(KernelWriter):
     # Recalculate bias length
     module.add(SMulI32(dst=sgpr("SrdBias+2"), src0=hex(biasBpe), src1=sgpr("SrdBias+2"), comment="scaled by BPE"))
     # Calculate global offset- macro tile 0 part
-    module.add(SMulI32(dst=sgpr(tmpSgpr), src0=kernel["MacroTile0"], src1=sgpr("WorkGroup0"), comment="wgp0 * MT0"))
-    module.add(VAddU32(dst=vgpr(offsetVgpr), src0=sgpr(tmpSgpr), src1=vgpr("Serial"), comment="coord 0 = wgp0 * MT0 + thread offset"))
+    module.add(SMulI32(dst=sgpr(tmpSgpr), src0=kernel["MacroTile%d"%dim], src1=sgpr("WorkGroup%d"%dim), comment="wgp%d * MT%d"%(dim, dim)))
+    module.add(VAddU32(dst=vgpr(offsetVgpr), src0=sgpr(tmpSgpr), src1=vgpr("Serial"), comment="coord %d = wgp%d * MT%d + thread offset"%(dim, dim, dim)))
     module.add(SMulI32(dst=sgpr(tmpSgpr), src0=sgpr("BiasStride"), src1=sgpr("WorkGroup2"), comment="Stride * WG"))
-    module.add(VAddU32(dst=vgpr(offsetVgpr), src0=sgpr(tmpSgpr), src1=vgpr(offsetVgpr), comment="coord 0 = wgp0 * MT0 + thread offset + Stride * WG"))
+    module.add(VAddU32(dst=vgpr(offsetVgpr), src0=sgpr(tmpSgpr), src1=vgpr(offsetVgpr), comment="coord %d = wgp%d * MT%d + thread offset + Stride * WG"%(dim, dim, dim)))
     module.add(VLShiftLeftB32(dst=vgpr(offsetVgpr), \
                               shiftHex=hex(log2(biasBpe)), \
                               src=vgpr(offsetVgpr), \
@@ -9149,7 +9305,7 @@ class KernelWriterAssembly(KernelWriter):
     addr0 = vgpr(offsetVgpr)
     addr1 = sgpr("SrdBias", 4)
     divisor = kernel["SubGroup0"] * kernel["SubGroup1"]
-    turn    = ceil(kernel["MacroTile0"] / (divisor * gwvw))
+    turn    = ceil(kernel["MacroTile%d"%dim] / (divisor * gwvw))
     offset  = (divisor * gwvw) * biasBpe
     tmpVgprN = tmpVgpr1
     for i in range(turn):

--- a/tensilelite/Tensile/KernelWriterBetaOnly.py
+++ b/tensilelite/Tensile/KernelWriterBetaOnly.py
@@ -95,6 +95,8 @@ class KernelWriterBetaOnly(KernelWriterBase):
 
     if self.state["ProblemType"]["BetaOnlyUseBias"]:
       kStr += "  unsigned int strideBias,%s" % (self.endLine)
+      if self.state["ProblemType"]["UseBias"] == 3:
+        kStr += "  unsigned int biasDim,%s" % (self.endLine)
 
     # sizes
     for i in range(0, self.state["ProblemType"]["NumIndicesC"]):
@@ -243,11 +245,16 @@ class KernelWriterBetaOnly(KernelWriterBase):
 
     biasStr = ""
     if self.state["ProblemType"]["BetaOnlyUseBias"]:
-
+      id_str = "id0"
+      if self.state["ProblemType"]["UseBias"] == 3:
+        id_str = "idb"
+        kStr += "  %s idb = ( arg.biasDim == 0 ? (%s)id0 : id1);%s" % (self.uint64Str, self.uint64Str, self.endLine)
+      elif self.state["ProblemType"]["UseBias"] == 2:
+        id_str = "id1"
       if problemType["NumIndicesC"] > 2:
-        biasStr = " + ((" + self.datatype + ")(Bias == 0 ? 0 : GLOBAL_BIAS((%s)id0, id2)))"% (self.uint64Str)
+        biasStr = " + ((" + self.datatype + ")(Bias == 0 ? 0 : GLOBAL_BIAS((%s)%s, id2)))"% (self.uint64Str, id_str)
       else:
-        biasStr = " + ((" + self.datatype + ")(Bias == 0 ? 0 : Bias[id0]))"
+        biasStr = " + ((" + self.datatype + ")(Bias == 0 ? 0 : Bias[%s]))"%id_str
 
     ########################################
     # zero

--- a/tensilelite/Tensile/KernelWriterConversion.py
+++ b/tensilelite/Tensile/KernelWriterConversion.py
@@ -165,6 +165,12 @@ class KernelWriterConversion(KernelWriterBase):
     kStr += "  unsigned char gsu;%s" % (self.endLine)
     kStr += "  unsigned char reserved[3];%s" % (self.endLine)
 
+    if self.state["ProblemType"]["UseBias"] and \
+        (not self.state["ProblemType"]["Gradient"] or \
+          (self.state["ProblemType"]["Gradient"] and (self.state["ProblemType"]["BiasSrc"] == "A" or self.state["ProblemType"]["BiasSrc"] == "B"))):
+      if self.state["ProblemType"]["UseBias"] == 3:
+        kStr += "  unsigned int biasDim;%s" % (self.endLine)
+
     # argument structure end
     kStr += "};" + self.endLine
 
@@ -398,10 +404,17 @@ class KernelWriterConversion(KernelWriterBase):
     if self.state["ProblemType"]["UseBias"] and \
        (not self.state["ProblemType"]["Gradient"] or \
          (self.state["ProblemType"]["Gradient"] and (self.state["ProblemType"]["BiasSrc"] == "A" or self.state["ProblemType"]["BiasSrc"] == "B"))):
+
+      id_str = "id0"
+      if self.state["ProblemType"]["UseBias"] == 3:
+        id_str = "idb"
+        kStr += "  %s idb = ( arg.biasDim == 0 ? (%s)id0 : id1);%s" % (self.uint64Str, self.uint64Str, self.endLine)
+      elif self.state["ProblemType"]["UseBias"] == 2:
+        id_str = "id1"
       if problemType["NumIndicesC"] > 2:
-        kStr += "  %s idxBias = GLOBAL_BIAS((%s)id0, id2);%s" % (self.uint64Str, self.uint64Str, self.endLine)
+        kStr += "  %s idxBias = GLOBAL_BIAS((%s)%s, id2);%s" % (self.uint64Str, self.uint64Str, id_str, self.endLine)
       else:
-        kStr += "  %s idxBias = id0;%s" % (self.uint64Str, self.uint64Str, self.endLine)
+        kStr += "  %s idxBias = %s;%s" % (self.uint64Str, id_str, self.endLine)
 
 
     ########################################
@@ -620,9 +633,24 @@ class KernelWriterConversion(KernelWriterBase):
     #Bias
     if self.state["ProblemType"]["UseBias"] and (not self.state["ProblemType"]["Gradient"]):
       kStr += "  if(arg.Bias != 0){" + self.endLine
-      for vIdx in range(self.num_dword_load):
-        kStr += "    %s[%d] += (%s)arg.Bias[idxBias+%d];%s" % (accumStr, vIdx, intermediateDataType, vIdx, self.endLine)
-      kStr += "  }" + self.endLine
+      if self.state["ProblemType"]["UseBias"] == 3:
+        kStr += "    if(arg.biasDim == 0){" + self.endLine
+        for vIdx in range(self.num_dword_load):
+          kStr += "      %s[%d] += (%s)arg.Bias[idxBias+%d];%s" % (accumStr, vIdx, intermediateDataType, vIdx, self.endLine)
+        kStr += "    }else{" + self.endLine
+        for vIdx in range(self.num_dword_load):
+          kStr += "      %s[%d] += (%s)arg.Bias[idxBias];%s" % (accumStr, vIdx, intermediateDataType, self.endLine)
+        kStr += "    }" + self.endLine
+        kStr += "  }" + self.endLine
+      elif self.state["ProblemType"]["UseBias"] == 2:
+        for vIdx in range(self.num_dword_load):
+          kStr += "    %s[%d] += (%s)arg.Bias[idxBias];%s" % (accumStr, vIdx, intermediateDataType, self.endLine)
+        kStr += "  }" + self.endLine
+      else:
+        for vIdx in range(self.num_dword_load):
+          kStr += "    %s[%d] += (%s)arg.Bias[idxBias+%d];%s" % (accumStr, vIdx, intermediateDataType, vIdx, self.endLine)
+        kStr += "  }" + self.endLine
+
       kStr += self.endLine
 
     #Handle E
@@ -735,6 +763,8 @@ class KernelWriterConversion(KernelWriterBase):
         name += "_BiasSrc%s"%(self.state["ProblemType"]["BiasSrc"])
       else:
         name += "_Bias%s"%self.state["ProblemType"]["BiasDataType"].toChar()
+        if self.state["ProblemType"]["UseBias"] > 1:
+          name += "_BD%s"%("N" if self.state["ProblemType"]["UseBias"] == 2 else "MN")
     if self.state["ProblemType"]["UseE"]:
       if self.state["ProblemType"]["Gradient"]:
         name += "_Grad%s"%self.state["ProblemType"]["DataTypeE"].toChar()

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -498,6 +498,8 @@ class ProblemType(Mapping):
           name += i.toChar()
       if self["BiasSrc"] and self["Gradient"]: # Show bias src if gradient = True
         name += "_BiasSrc%s"%self["BiasSrc"]
+      if self["UseBias"] > 1:
+        name += "_BD%s"%("N" if self["UseBias"] == 2 else "MN")
     if self["UseE"]:
       if self["Gradient"]:
         name += "_Grad%s"%self["DataTypeE"].toChar()
@@ -949,6 +951,24 @@ class BiasTypeArgs:
     s = "BiasTypesArgs\n"
     return s
 
+class BiasDimArgs:
+
+  ########################################
+  def __init__(self, problemType, config):
+    self.biasDims = []
+    self.totalProblemSizes = 0
+    if problemType["UseBias"]:
+      for bdim in config:
+        dim = int(bdim)
+        if dim not in [0, 1]:
+          printWarning("Bias Dim: must be 0 or 1, current is %s."%(dim))
+        self.biasDims.append(dim)
+      self.totalProblemSizes = len(self.biasDims)
+
+  def __str__(self):
+    s = "BiasDimArgs\n"
+    return s
+
 ################################################################################
 # Activation
 ################################################################################
@@ -1128,7 +1148,7 @@ class Solution(collections.abc.Mapping):
             state = {}
             state["ProblemType"] = deepcopy(self["ProblemType"])
             state["ProblemType"]["GroupedGemm"] = False
-            state["ProblemType"]["UseBias"] = False
+            state["ProblemType"]["UseBias"] = 0
             state["KernelLanguage"] = "Source"
             state["GlobalSplitU"] = globalSplitU
             state["UnrollOnly"] = unrollOnly
@@ -1183,7 +1203,7 @@ class Solution(collections.abc.Mapping):
       state = {}
       state["ProblemType"] = deepcopy(self["ProblemType"])
       state["ProblemType"]["GroupedGemm"] = False
-      state["ProblemType"]["UseBias"] = False
+      state["ProblemType"]["UseBias"] = 0
       state["ProblemType"]["BiasDataTypeList"] = []
       state["KernelLanguage"] = "Source"
       state["_GlobalAccumulation"] = self["_GlobalAccumulation"]

--- a/tensilelite/Tensile/Source/client/include/ClientProblemFactory.hpp
+++ b/tensilelite/Tensile/Source/client/include/ClientProblemFactory.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -75,7 +75,7 @@ namespace Tensile
             bool m_highPrecisionAccumulate;
             bool m_deterministicMode;
             bool m_cEqualsD;
-            bool m_useBias;
+            int  m_useBias;
             int  m_biasSrc;
             bool m_useScaleAB;
             bool m_useScaleCD;
@@ -88,6 +88,7 @@ namespace Tensile
             PerformanceMetric                m_performanceMetric;
             ActivationType                   m_activationType;
             std::vector<DataType>            m_biasTypeArgs;
+            std::vector<int>                 m_biasDimArgs;
             bool                             m_activationNoGuard;
             std::vector<ActivationType>      m_activationEnumArg;
             size_t                           m_maxWorkspaceSize = 0;

--- a/tensilelite/Tensile/Source/client/include/LogReporter.hpp
+++ b/tensilelite/Tensile/Source/client/include/LogReporter.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -115,6 +115,7 @@ namespace Tensile
                                                                      OperationIdentifier,
                                                                      ProblemSizes,
                                                                      BiasType,
+                                                                     BiasDim,
                                                                      ActivationType,
                                                                      SolutionName,
                                                                      Validation,

--- a/tensilelite/Tensile/Source/client/include/ResultReporter.hpp
+++ b/tensilelite/Tensile/Source/client/include/ResultReporter.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -78,6 +78,7 @@ namespace Tensile
             const std::string ProblemSizes = "problem-sizes";
 
             const std::string BiasType       = "bias-type";
+            const std::string BiasDim        = "bias-dim";
             const std::string ActivationType = "activation-type";
 
             // Solution information

--- a/tensilelite/Tensile/Source/client/main.cpp
+++ b/tensilelite/Tensile/Source/client/main.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -247,12 +247,13 @@ namespace Tensile
                 ("activation-no-guard",          po::value<bool>()->default_value(false), "Use activation guard to deall with nan outputs.")
                 ("activation-additional-args",vector_default_empty<std::string>(), "Activation additional floating-point number arguments.")
                 ("activation-enum-args",      po::value<std::vector<ActivationType>>()->default_value(std::vector<ActivationType>(1, ActivationType::None), "[]"), "Activation enum argument.")
-                ("use-bias",                  po::value<bool>()->default_value(false), "Use bias.")
+                ("use-bias",                  po::value<int>()->default_value(0), "Use bias.")
                 ("bias-source",               po::value<int>()->default_value(3), "Bias source.")
                 ("use-scaleAB",               po::value<bool>()->default_value(false), "Use scaleAB.")
                 ("use-scaleCD",               po::value<bool>()->default_value(false), "Use scaleCD.")
                 ("use-scaleAlphaVec",         po::value<bool>()->default_value(false), "Use scaleAlphaVec.")
                 ("bias-type-args",            po::value<std::vector<DataType>>()->default_value(std::vector<DataType>(1, DataType::None), "[]"), "Bias data type args.")
+                ("bias-dim-args",             po::value<std::vector<int>>()->default_value(std::vector<int>(1, 0), "[]"), "Bias dimensions args.")
                 ("use-e",                     po::value<bool>()->default_value(false), "Use E.")
                 ("use-gradient",              po::value<bool>()->default_value(false), "Use gradient.")
                 ("use-user-args",             po::value<bool>()->default_value(false), "Use user argument structure as kernel input.")

--- a/tensilelite/Tensile/Source/client/source/ProgressListener.cpp
+++ b/tensilelite/Tensile/Source/client/source/ProgressListener.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -80,6 +80,7 @@ namespace Tensile
             if(problem.useBias())
             {
                 m_reporter->report(ResultKey::BiasType, ToString(problem.getParams().biasEnum()));
+                m_reporter->report(ResultKey::BiasDim, problem.getParams().biasDim());
             }
             else
             {

--- a/tensilelite/Tensile/Source/client/source/Reference.cpp
+++ b/tensilelite/Tensile/Source/client/source/Reference.cpp
@@ -872,7 +872,11 @@ namespace Tensile
                 if(problem.useBias() && inputs.bias && !problem.useGradient())
                 {
                     auto        biasIndex = problem.bias().index(biasCoord);
-                    int         pos       = int(dNum % problem.d().sizes()[0]) + biasIndex;
+                    int         pos       = 0;
+                    if(problem.getParams().biasDim())
+                        pos = int(dNum / problem.d().sizes()[0]) + biasIndex;
+                    else
+                        pos = int(dNum % problem.d().sizes()[0]) + biasIndex;
                     Accumulator bias      = GetValue<Accumulator>(
                         problem.bias().dataType(), inputs.bias, pos, aConjugate);
                     resultD += bias;

--- a/tensilelite/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -78,6 +78,15 @@ namespace Tensile
             return m_biasType;
         }
 
+        void setBiasDim(int biasDim)
+        {
+            m_biasDim = biasDim;
+        }
+
+        int biasDim() const
+        {
+            return m_biasDim;
+        } 
         void setActivationEnum(ActivationType activationEnum)
         {
             m_activationType = activationEnum;
@@ -97,6 +106,7 @@ namespace Tensile
         uint8_t        m_gsu            = 0; // default value
         uint8_t        m_wgm            = 0; // default value
         DataType       m_biasType       = DataType::None;
+        int            m_biasDim        = 0;
         ActivationType m_activationType = ActivationType::None;
     };
 
@@ -576,7 +586,7 @@ namespace Tensile
             m_useE = useE;
         }
 
-        void setUseBias(bool useBias)
+        void setUseBias(int useBias)
         {
             m_useBias = useBias;
         }
@@ -601,7 +611,7 @@ namespace Tensile
             return m_useE;
         }
 
-        bool useBias() const
+        int useBias() const
         {
             return m_useBias;
         }
@@ -639,9 +649,11 @@ namespace Tensile
                      size_t                         length,
                      size_t                         stride,
                      bool                           isOutput = false,
-                     ContractionProblemGemm::TENSOR src      = ContractionProblemGemm::TENSOR::D)
+                     ContractionProblemGemm::TENSOR src      = ContractionProblemGemm::TENSOR::D,
+                     int                            biasDim  = 0)
         {
             setParams().setBiasEnum(type);
+            setParams().setBiasDim(biasDim);
             m_biasSrc = src;
             if(type != DataType::None && m_useBias)
             {
@@ -1073,7 +1085,7 @@ namespace Tensile
         bool           m_eligibleForPK           = true;
         bool           m_useGradient             = false;
         bool           m_useE                    = false;
-        bool           m_useBias                 = false;
+        int            m_useBias                 = 0;
         bool           m_useScaleAB              = false;
         bool           m_useScaleCD              = false;
         bool           m_useScaleAlphaVec        = false;

--- a/tensilelite/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
@@ -1993,10 +1993,10 @@ namespace Tensile
                     HasIndex = false,
                     HasValue = true
                 };
-                bool value;
+                int value;
 
                 UseBiasEqual() = default;
-                UseBiasEqual(bool value)
+                UseBiasEqual(int value)
                     : value(value)
                 {
                 }
@@ -2237,7 +2237,16 @@ namespace Tensile
                                 if(problem.biasSrc() == ContractionProblemGemm::TENSOR::A
                                    || problem.biasSrc() == ContractionProblemGemm::TENSOR::D)
                                 {
-                                    if(length != problem.d().sizes()[0])
+                                    auto eLength = (problem.useBias() == 1 || problem.biasSrc() != ContractionProblemGemm::TENSOR::D) 
+                                                     ? problem.d().sizes()[0]
+                                                     : (problem.useBias() == 2) 
+                                                     ? problem.d().sizes()[1]
+                                                     : (problem.useBias() == 3)
+                                                     ? (problem.getParams().biasDim() == 1)
+                                                     ? problem.d().sizes()[1] 
+                                                     : problem.d().sizes()[0]
+                                                     : -1;
+                                    if(length < eLength)
                                         return false;
                                 }
                                 else if(problem.biasSrc() == ContractionProblemGemm::TENSOR::B)

--- a/tensilelite/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
@@ -452,7 +452,7 @@ namespace Tensile
             bool                  highPrecisionAccumulate   = false;
             bool                  useBeta                   = true;
             bool                  useGradient               = false;
-            bool                  useBias                   = false;
+            int                   useBias                   = 0;
             bool                  useE                      = false;
             bool                  useScaleAB                = false;
             bool                  useScaleCD                = false;

--- a/tensilelite/Tensile/TensileClientConfig.py
+++ b/tensilelite/Tensile/TensileClientConfig.py
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -183,7 +183,7 @@ def TensileClientConfig(userArgs):
         Common.globalParameters[key] = value
 
     # write output
-    ClientWriter.writeClientConfigIni(sizes, conProblemType, "", [], "", args.OutputConfig, None)
+    ClientWriter.writeClientConfigIni(sizes, conProblemType, "", "", [], "", args.OutputConfig, None)
 
 
 def main():

--- a/tensilelite/Tensile/TensileRetuneLibrary.py
+++ b/tensilelite/Tensile/TensileRetuneLibrary.py
@@ -1,6 +1,6 @@
 ###############################################################################
 #
-# Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -88,7 +88,7 @@ def runBenchmarking(solutions, problemSizes, outPath, update):
 
     pushWorkingPath(shortName)
     pushWorkingPath("source")
-    BenchmarkProblems.writeBenchmarkFiles(benchmarkDir, solutions, problemSizes , "", shortName, [])
+    BenchmarkProblems.writeBenchmarkFiles(benchmarkDir, solutions, problemSizes , "", "", shortName, [])
     popWorkingPath() # source
 
     libraryLogicPath = None

--- a/tensilelite/Tensile/Tests/common/exception/f16_cf32_nan.yaml
+++ b/tensilelite/Tensile/Tests/common/exception/f16_cf32_nan.yaml
@@ -29,7 +29,7 @@ BenchmarkProblems:
       Batched: True
       Gradient: True
       UseE: True
-      UseBias:       False
+      UseBias:       0
       Activation:    True
       ActivationHPA: True
       UseScaleDVec:     False

--- a/tensilelite/Tensile/Tests/common/gemm/8r_b_s.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/8r_b_s.yaml
@@ -35,7 +35,7 @@ BenchmarkProblems:
       Activation: True
       UseScaleAB: True
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: ['b']
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -97,7 +97,7 @@ BenchmarkProblems:
       Activation: True
       UseScaleAB: True
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: ['b']
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:

--- a/tensilelite/Tensile/Tests/common/gemm/bf16_tn.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/bf16_tn.yaml
@@ -23,7 +23,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True

--- a/tensilelite/Tensile/Tests/common/gemm/fp16_HH_BHS_bf16mfma.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/fp16_HH_BHS_bf16mfma.yaml
@@ -25,7 +25,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True

--- a/tensilelite/Tensile/Tests/common/gemm/fp16_tn.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/fp16_tn.yaml
@@ -23,7 +23,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True

--- a/tensilelite/Tensile/Tests/common/gemm/fp16_use_e.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/fp16_use_e.yaml
@@ -26,7 +26,7 @@ BenchmarkProblems:
       UseBeta: True
       Batched: True
       UseE: True
-      UseBias:       True
+      UseBias:       1
       Activation:    True
       ActivationHPA: True
       UseScaleDVec:     False
@@ -77,7 +77,7 @@ BenchmarkProblems:
       UseBeta: True
       Batched: True
       UseE: True
-      UseBias:       True
+      UseBias:       1
       Activation:    True
       ActivationHPA: True
       UseScaleDVec:     False

--- a/tensilelite/Tensile/Tests/common/gemm/fp16fp32mix.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/fp16fp32mix.yaml
@@ -33,7 +33,7 @@ BenchmarkProblems:
       TransposeB: 0
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -87,7 +87,7 @@ BenchmarkProblems:
       TransposeB: 0
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -141,7 +141,7 @@ BenchmarkProblems:
       TransposeB: 1
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -195,7 +195,7 @@ BenchmarkProblems:
       TransposeB: 1
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -252,7 +252,7 @@ BenchmarkProblems:
       TransposeB: 0
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -306,7 +306,7 @@ BenchmarkProblems:
       TransposeB: 1
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -360,7 +360,7 @@ BenchmarkProblems:
       TransposeB: 0
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -414,7 +414,7 @@ BenchmarkProblems:
       TransposeB: 1
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:

--- a/tensilelite/Tensile/Tests/common/gemm/fp32_tn.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/fp32_tn.yaml
@@ -24,7 +24,7 @@ BenchmarkProblems:
       TransposeB: 0
       UseBeta: True
       Batched: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
     - # BenchmarkProblemSizeGroup - Standard - All problem

--- a/tensilelite/Tensile/Tests/common/gemm/fp8.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/fp8.yaml
@@ -41,7 +41,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: True
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -114,7 +114,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: True
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -177,7 +177,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: True
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:

--- a/tensilelite/Tensile/Tests/common/gemm/fp8bf8ss.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/fp8bf8ss.yaml
@@ -32,7 +32,7 @@ BenchmarkProblems:
       TransposeB: 0
       UseBeta: True
       Batched: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s,b]
       UseScaleAB: True
       Activation:    True
@@ -105,7 +105,7 @@ BenchmarkProblems:
       TransposeB: 1
       UseBeta: True
       Batched: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s,b]
       UseScaleAB: True
       Activation:    True

--- a/tensilelite/Tensile/Tests/common/gemm/fp8fp16mix_fp8ss.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/fp8fp16mix_fp8ss.yaml
@@ -33,7 +33,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: False
       UseScaleAlphaVec: False
-      UseBias: False
+      UseBias: 0
       BiasDataTypeList: [s,b,h]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -101,7 +101,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: False
       UseScaleAlphaVec: False
-      UseBias: False
+      UseBias: 0
       BiasDataTypeList: [s,b,h]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -168,7 +168,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: False
       UseScaleAlphaVec: False
-      UseBias: False
+      UseBias: 0
       BiasDataTypeList: [s,b,h]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -236,7 +236,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: False
       UseScaleAlphaVec: False
-      UseBias: False
+      UseBias: 0
       BiasDataTypeList: [s,b,h]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -308,7 +308,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: False
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s,b]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -545,7 +545,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: False
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s,b]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:

--- a/tensilelite/Tensile/Tests/common/gemm/fp8fp16mix_hfp8s.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/fp8fp16mix_hfp8s.yaml
@@ -43,7 +43,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: True
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s,b]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -106,7 +106,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: True
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s,b]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -169,7 +169,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: True
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s,b]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -235,7 +235,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: True
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s,b]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -297,7 +297,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: True
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s,b]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -359,7 +359,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: True
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s,b]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -422,7 +422,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: True
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s,b]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -488,7 +488,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: True
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s,b]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -550,7 +550,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: True
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s,b]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -612,7 +612,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: True
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s,b]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -675,7 +675,7 @@ BenchmarkProblems:
       UseScaleAB: True
       UseScaleCD: True
       UseScaleAlphaVec: True
-      UseBias: True
+      UseBias: 1
       BiasDataTypeList: [s,b]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:

--- a/tensilelite/Tensile/Tests/common/gemm/gemm_bias_strided_batched.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/gemm_bias_strided_batched.yaml
@@ -28,7 +28,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -93,7 +93,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -158,7 +158,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -223,7 +223,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -288,7 +288,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -353,7 +353,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -418,7 +418,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -483,7 +483,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -549,7 +549,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -615,7 +615,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True

--- a/tensilelite/Tensile/Tests/common/gemm/gemm_bias_strided_batched_broadcast.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/gemm_bias_strided_batched_broadcast.yaml
@@ -28,7 +28,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -93,7 +93,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -158,7 +158,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -223,7 +223,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -288,7 +288,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -353,7 +353,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -418,7 +418,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -483,7 +483,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -549,7 +549,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -615,7 +615,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True

--- a/tensilelite/Tensile/Tests/common/gemm/gemm_bias_strided_batched_broadcast_gfx940.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/gemm_bias_strided_batched_broadcast_gfx940.yaml
@@ -27,7 +27,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -92,7 +92,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -157,7 +157,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -222,7 +222,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -287,7 +287,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -352,7 +352,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -417,7 +417,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -482,7 +482,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -548,7 +548,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -614,7 +614,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True

--- a/tensilelite/Tensile/Tests/common/gemm/gemm_bias_strided_batched_gfx940.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/gemm_bias_strided_batched_gfx940.yaml
@@ -27,7 +27,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -92,7 +92,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -157,7 +157,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -222,7 +222,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -287,7 +287,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -352,7 +352,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -417,7 +417,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -482,7 +482,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -548,7 +548,7 @@ BenchmarkProblems:
       TransposeA: 0
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True
@@ -614,7 +614,7 @@ BenchmarkProblems:
       TransposeA: 1
       TransposeB: 0
       UseBeta: True
-      UseBias: True
+      UseBias: 1
       Batched: True
       Activation: True
       ActivationHPA: True

--- a/tensilelite/Tensile/Tests/common/gradient/fp16_gradient_activation.yaml
+++ b/tensilelite/Tensile/Tests/common/gradient/fp16_gradient_activation.yaml
@@ -28,7 +28,7 @@ BenchmarkProblems:
       Batched: True
       Gradient: True
       UseE: True
-      UseBias:       False
+      UseBias:       0
       Activation:    True
       ActivationHPA: True
       UseScaleDVec:     False
@@ -84,7 +84,7 @@ BenchmarkProblems:
       Batched: True
       Gradient: True
       UseE: True
-      UseBias:       False
+      UseBias:       0
       Activation:    True
       ActivationHPA: True
       UseScaleDVec:     False

--- a/tensilelite/Tensile/Tests/common/gradient/fp16_gradient_bias.yaml
+++ b/tensilelite/Tensile/Tests/common/gradient/fp16_gradient_bias.yaml
@@ -29,7 +29,7 @@ BenchmarkProblems:
       Batched: True
       Gradient: True
       UseE: True
-      UseBias: True
+      UseBias: 1
       BiasSrc: "D"
       Activation: True
       ActivationHPA: True
@@ -98,7 +98,7 @@ BenchmarkProblems:
       Batched: True
       Gradient: True
       UseE: False
-      UseBias: True
+      UseBias: 1
       BiasSrc: "A"
       Activation: False
       ActivationHPA: False
@@ -168,7 +168,7 @@ BenchmarkProblems:
       Batched: True
       Gradient: True
       UseE: False
-      UseBias: True
+      UseBias: 1
       BiasSrc: "A"
       Activation: False
       ActivationHPA: False
@@ -241,7 +241,7 @@ BenchmarkProblems:
       Batched: True
       Gradient: True
       UseE: False
-      UseBias: True
+      UseBias: 1
       BiasSrc: "A"
       Activation: False
       ActivationHPA: False
@@ -312,7 +312,7 @@ BenchmarkProblems:
       Batched: True
       Gradient: True
       UseE: False
-      UseBias: True
+      UseBias: 1
       BiasSrc: "B"
       Activation: False
       ActivationHPA: False
@@ -386,7 +386,7 @@ BenchmarkProblems:
       Batched: True
       Gradient: True
       UseE: False
-      UseBias: True
+      UseBias: 1
       BiasSrc: "B"
       Activation: False
       ActivationHPA: False

--- a/tensilelite/Tensile/Tests/common/gradient/fp8bf8ss_gradient_bias_b.yaml
+++ b/tensilelite/Tensile/Tests/common/gradient/fp8bf8ss_gradient_bias_b.yaml
@@ -33,7 +33,7 @@ BenchmarkProblems:
       UseBeta: True
       Batched: True
       Gradient: True
-      UseBias: True
+      UseBias: 1
       BiasSrc: "B"
       BiasDataTypeList: [s,b]
       UseScaleAB: True
@@ -103,7 +103,7 @@ BenchmarkProblems:
       UseBeta: True
       Batched: True
       Gradient: True
-      UseBias: True
+      UseBias: 1
       BiasSrc: "B"
       BiasDataTypeList: [s,b]
       UseScaleAB: True

--- a/tensilelite/Tensile/Tests/common/groupedgemm/grouped_gemm.yaml
+++ b/tensilelite/Tensile/Tests/common/groupedgemm/grouped_gemm.yaml
@@ -25,7 +25,7 @@ BenchmarkProblems:
       TransposeB: 0
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
       Activation:    True
       ActivationHPA: True
       GroupedGemm:   True
@@ -76,7 +76,7 @@ BenchmarkProblems:
       TransposeB: 0
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
       Activation:    True
       ActivationHPA: True
       GroupedGemm:   True
@@ -126,7 +126,7 @@ BenchmarkProblems:
       TransposeB: 1
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
       Activation:    True
       ActivationHPA: True
       GroupedGemm:   True
@@ -176,7 +176,7 @@ BenchmarkProblems:
       TransposeB: 1
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
       Activation:    True
       ActivationHPA: True
       GroupedGemm:   True

--- a/tensilelite/Tensile/Tests/common/groupedgemm/grouped_gemm_ck_gfx941.yaml
+++ b/tensilelite/Tensile/Tests/common/groupedgemm/grouped_gemm_ck_gfx941.yaml
@@ -39,7 +39,7 @@ BenchmarkProblems:
       UseBeta: True
       Batched: True
 
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
 
@@ -128,7 +128,7 @@ BenchmarkProblems:
       UseBeta: True
       Batched: True
 
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
 
@@ -213,7 +213,7 @@ BenchmarkProblems:
       UseBeta: True
       Batched: True
 
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
 
@@ -297,7 +297,7 @@ BenchmarkProblems:
       UseBeta: True
       Batched: True
 
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
 

--- a/tensilelite/Tensile/Tests/common/groupedgemm/grouped_gemm_ck_gfx942.yaml
+++ b/tensilelite/Tensile/Tests/common/groupedgemm/grouped_gemm_ck_gfx942.yaml
@@ -39,7 +39,7 @@ BenchmarkProblems:
       UseBeta: True
       Batched: True
 
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
 
@@ -128,7 +128,7 @@ BenchmarkProblems:
       UseBeta: True
       Batched: True
 
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
 
@@ -213,7 +213,7 @@ BenchmarkProblems:
       UseBeta: True
       Batched: True
 
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
 
@@ -297,7 +297,7 @@ BenchmarkProblems:
       UseBeta: True
       Batched: True
 
-      UseBias: True
+      UseBias: 1
       Activation: True
       UseScaleAlphaVec: True
 

--- a/tensilelite/Tensile/Tests/common/groupedgemm/grouped_gemm_userargs.yaml
+++ b/tensilelite/Tensile/Tests/common/groupedgemm/grouped_gemm_userargs.yaml
@@ -33,7 +33,7 @@ BenchmarkProblems:
       TransposeB: 0
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
       UseE:          False
       Activation:    True
       ActivationHPA: True
@@ -86,7 +86,7 @@ BenchmarkProblems:
       TransposeB: 0
       UseBeta: True
       Batched: True
-      UseBias:       False
+      UseBias:       0
       UseE:          False
       Activation:    False
       ActivationHPA: False
@@ -138,7 +138,7 @@ BenchmarkProblems:
       TransposeB: 0
       UseBeta: True
       Batched: True
-      UseBias:       False
+      UseBias:       0
       UseE:          False
       Activation:    False
       ActivationHPA: False

--- a/tensilelite/Tensile/Tests/common/sparse/bf16_activation.yaml
+++ b/tensilelite/Tensile/Tests/common/sparse/bf16_activation.yaml
@@ -64,11 +64,10 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
         - ActivationArgs:
           - [Enum: none]
           - [Enum: abs]
@@ -130,11 +129,10 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
         - ActivationArgs:
           - [Enum: none]
           - [Enum: abs]
@@ -196,11 +194,10 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
         - ActivationArgs:
           - [Enum: none]
           - [Enum: abs]
@@ -262,11 +259,10 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
         - ActivationArgs:
           - [Enum: none]
           - [Enum: abs]

--- a/tensilelite/Tensile/Tests/common/sparse/fp16_activation.yaml
+++ b/tensilelite/Tensile/Tests/common/sparse/fp16_activation.yaml
@@ -64,11 +64,10 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
         - ActivationArgs:
           - [Enum: none]
           - [Enum: abs]
@@ -130,11 +129,10 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
         - ActivationArgs:
           - [Enum: none]
           - [Enum: abs]
@@ -196,11 +194,10 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
         - ActivationArgs:
           - [Enum: none]
           - [Enum: abs]
@@ -262,11 +259,10 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
         - ActivationArgs:
           - [Enum: none]
           - [Enum: abs]

--- a/tensilelite/Tensile/Tests/common/sparse/i8_activation.yaml
+++ b/tensilelite/Tensile/Tests/common/sparse/i8_activation.yaml
@@ -64,11 +64,10 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
         - ActivationArgs:
           - [Enum: none]
           - [Enum: abs]
@@ -130,11 +129,10 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
         - ActivationArgs:
           - [Enum: none]
           - [Enum: abs]
@@ -196,10 +194,10 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
         - ActivationArgs:
           - [Enum: none]
           - [Enum: abs]
@@ -261,11 +259,10 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
         - ActivationArgs:
           - [Enum: none]
           - [Enum: abs]

--- a/tensilelite/Tensile/Tests/common/sparse/spmm_bf16.yaml
+++ b/tensilelite/Tensile/Tests/common/sparse/spmm_bf16.yaml
@@ -50,7 +50,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -72,41 +72,23 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #########################################
   ## TN - standard
@@ -143,7 +125,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -165,41 +147,23 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #######################################
   # NT - standard
@@ -236,7 +200,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -258,41 +222,23 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #######################################
   # TT - standard
@@ -329,7 +275,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -351,38 +297,20 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]

--- a/tensilelite/Tensile/Tests/common/sparse/spmm_bf16_sb.yaml
+++ b/tensilelite/Tensile/Tests/common/sparse/spmm_bf16_sb.yaml
@@ -28,7 +28,7 @@ BenchmarkProblems:
       TransposeA: False
       TransposeB: False
       UseBeta: True
-      UseBias: True
+      UseBias: 3
       Sparse: 2
       Batched: True
       Activation: True
@@ -51,7 +51,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -74,42 +74,24 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
         - BiasTypeArgs: ['h', 's']
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #########################################
   ## TN - standard
@@ -124,7 +106,7 @@ BenchmarkProblems:
       TransposeA: True
       TransposeB: False
       UseBeta: True
-      UseBias: True
+      UseBias: 3
       Sparse: 2
       Batched: True
       Activation: True
@@ -147,7 +129,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -170,42 +152,24 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
         - BiasTypeArgs: ['h', 's']
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #######################################
   # NT - standard
@@ -220,7 +184,7 @@ BenchmarkProblems:
       TransposeA: False
       TransposeB: True
       UseBeta: True
-      UseBias: True
+      UseBias: 3
       Sparse: 2
       Batched: True
       Activation: True
@@ -243,7 +207,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -266,42 +230,24 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
         - BiasTypeArgs: ['h', 's']
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #######################################
   # TT - standard
@@ -316,7 +262,7 @@ BenchmarkProblems:
       TransposeA: True
       TransposeB: True
       UseBeta: True
-      UseBias: True
+      UseBias: 3
       Sparse: 2
       Batched: True
       Activation: True
@@ -339,7 +285,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -362,39 +308,21 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
         - BiasTypeArgs: ['h', 's']
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]

--- a/tensilelite/Tensile/Tests/common/sparse/spmm_fp16.yaml
+++ b/tensilelite/Tensile/Tests/common/sparse/spmm_fp16.yaml
@@ -32,6 +32,7 @@ BenchmarkProblems:
       Batched: True
       Activation: True
       ActivationHPA: True
+      UseBias: 3
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -50,7 +51,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -72,41 +73,25 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
+        - BiasTypeArgs: ['s', 'h']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #########################################
   ## TN - standard
@@ -125,6 +110,7 @@ BenchmarkProblems:
       Batched: True
       Activation: True
       ActivationHPA: True
+      UseBias: 3
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -143,7 +129,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -165,41 +151,25 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
+        - BiasTypeArgs: ['s', 'h']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #######################################
   # NT - standard
@@ -218,6 +188,7 @@ BenchmarkProblems:
       Batched: True
       Activation: True
       ActivationHPA: True
+      UseBias: 3
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -236,7 +207,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -258,41 +229,25 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
+        - BiasTypeArgs: ['s', 'h']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #######################################
   # TT - standard
@@ -311,6 +266,7 @@ BenchmarkProblems:
       Batched: True
       Activation: True
       ActivationHPA: True
+      UseBias: 3
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -329,7 +285,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -351,38 +307,22 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
+        - BiasTypeArgs: ['s', 'h']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]

--- a/tensilelite/Tensile/Tests/common/sparse/spmm_fp16_sb.yaml
+++ b/tensilelite/Tensile/Tests/common/sparse/spmm_fp16_sb.yaml
@@ -28,11 +28,12 @@ BenchmarkProblems:
       TransposeA: False
       TransposeB: False
       UseBeta: True
-      UseBias: True
+      UseBias: 3
       Sparse: 2
       Batched: True
       Activation: True
       ActivationHPA: True
+      UseBias: 3
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -51,7 +52,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -74,42 +75,25 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
-        - BiasTypeArgs: ['b', 's']
+        - BiasTypeArgs: ['s', 'h']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #########################################
   ## TN - standard
@@ -124,11 +108,12 @@ BenchmarkProblems:
       TransposeA: True
       TransposeB: False
       UseBeta: True
-      UseBias: True
+      UseBias: 3
       Sparse: 2
       Batched: True
       Activation: True
       ActivationHPA: True
+      UseBias: 3
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -147,7 +132,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -170,42 +155,25 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
-        - BiasTypeArgs: ['b', 's']
+        - BiasTypeArgs: ['s', 'h']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #######################################
   # NT - standard
@@ -220,11 +188,12 @@ BenchmarkProblems:
       TransposeA: False
       TransposeB: True
       UseBeta: True
-      UseBias: True
+      UseBias: 3
       Sparse: 2
       Batched: True
       Activation: True
       ActivationHPA: True
+      UseBias: 3
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -243,7 +212,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -266,42 +235,25 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
-        - BiasTypeArgs: ['b', 's']
+        - BiasTypeArgs: ['s', 'h']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #######################################
   # TT - standard
@@ -316,11 +268,12 @@ BenchmarkProblems:
       TransposeA: True
       TransposeB: True
       UseBeta: True
-      UseBias: True
+      UseBias: 3
       Sparse: 2
       Batched: True
       Activation: True
       ActivationHPA: True
+      UseBias: 3
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -339,7 +292,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -362,39 +315,22 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
-        - BiasTypeArgs: ['b', 's']
+        - BiasTypeArgs: ['s', 'h']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]

--- a/tensilelite/Tensile/Tests/common/sparse/spmm_i8.yaml
+++ b/tensilelite/Tensile/Tests/common/sparse/spmm_i8.yaml
@@ -32,6 +32,7 @@ BenchmarkProblems:
       Batched: True
       Activation: True
       ActivationHPA: True
+      UseBias: 3
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -50,7 +51,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64,128]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -72,38 +73,23 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
+        - BiasTypeArgs: ['s']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
 
@@ -124,6 +110,7 @@ BenchmarkProblems:
       Batched: True
       Activation: True
       ActivationHPA: True
+      UseBias: 3
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -142,7 +129,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64,128]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -164,41 +151,25 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
+        - BiasTypeArgs: ['s']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #######################################
   # NT - standard
@@ -217,6 +188,7 @@ BenchmarkProblems:
       Batched: True
       Activation: True
       ActivationHPA: True
+      UseBias: 3
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -235,7 +207,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64,128]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -257,41 +229,25 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
+        - BiasTypeArgs: ['s']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #######################################
   # TT - standard
@@ -310,6 +266,7 @@ BenchmarkProblems:
       Batched: True
       Activation: True
       ActivationHPA: True
+      UseBias: 3
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -328,7 +285,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64,128]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -350,38 +307,22 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
+        - BiasTypeArgs: ['s']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]

--- a/tensilelite/Tensile/Tests/common/sparse/spmm_i8_sb.yaml
+++ b/tensilelite/Tensile/Tests/common/sparse/spmm_i8_sb.yaml
@@ -28,7 +28,7 @@ BenchmarkProblems:
       TransposeA: False
       TransposeB: False
       UseBeta: True
-      UseBias: True
+      UseBias: 3
       Sparse: 2
       Batched: True
       Activation: True
@@ -51,7 +51,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64,128]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -74,39 +74,23 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
         - BiasTypeArgs: ['s']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
 
@@ -123,7 +107,7 @@ BenchmarkProblems:
       TransposeA: True
       TransposeB: False
       UseBeta: True
-      UseBias: True
+      UseBias: 3
       Sparse: 2
       Batched: True
       Activation: True
@@ -146,7 +130,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64,128]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -169,42 +153,25 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
         - BiasTypeArgs: ['s']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #######################################
   # NT - standard
@@ -219,7 +186,7 @@ BenchmarkProblems:
       TransposeA: False
       TransposeB: True
       UseBeta: True
-      UseBias: True
+      UseBias: 3
       Sparse: 2
       Batched: True
       Activation: True
@@ -242,7 +209,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64,128]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -265,42 +232,25 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
         - BiasTypeArgs: ['s']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #######################################
   # TT - standard
@@ -315,7 +265,7 @@ BenchmarkProblems:
       TransposeA: True
       TransposeB: True
       UseBeta: True
-      UseBias: True
+      UseBias: 3
       Sparse: 2
       Batched: True
       Activation: True
@@ -338,7 +288,7 @@ BenchmarkProblems:
         - VectorWidthA: [1,2,4]
         - VectorWidthB: [1,2,4]
         - DepthU: [32,64,128]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -361,39 +311,22 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
           - Exact: [16, 16, 1, 16] # classic format
           - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
-          - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [384, 384, 1, 16] # classic format
-          - Exact: [384, 384, 1, 24] # classic format
           - Exact: [384, 384, 1, 32] # classic format
           - Exact: [384, 384, 1, 64] # classic format
           - Exact: [384, 384, 1, 96] # classic format
           - Exact: [384, 384, 1, 128] # classic format
-          - Exact: [384, 384, 1, 136] # classic format
-          - Exact: [384, 384, 1, 256] # classic format
         - BiasTypeArgs: ['s']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]

--- a/tensilelite/Tensile/Tests/common/sparse/spmm_i8hs.yaml
+++ b/tensilelite/Tensile/Tests/common/sparse/spmm_i8hs.yaml
@@ -32,7 +32,7 @@ BenchmarkProblems:
       Batched: True
       Activation: True
       ActivationHPA: True
-      UseBias: True
+      UseBias: 3
       BiasDataTypeList: ['s']
 
     - # BenchmarkProblemSizeGroup - Standard
@@ -49,7 +49,7 @@ BenchmarkProblems:
           - [32, 32, 32, 1,  1,  7, 2,  1, 4 ]
         - GlobalReadVectorWidthA: [8]
         - DepthU: [32,64,128]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -76,9 +76,6 @@ BenchmarkProblems:
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -86,11 +83,9 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #########################################
   ## TN - standard
@@ -109,7 +104,7 @@ BenchmarkProblems:
       Batched: True
       Activation: True
       ActivationHPA: True
-      UseBias: True
+      UseBias: 3
       BiasDataTypeList: ['s']
 
     - # BenchmarkProblemSizeGroup - Standard
@@ -126,7 +121,7 @@ BenchmarkProblems:
           - [32, 32, 32, 1,  1,  7, 2,  1, 4 ]
         - GlobalReadVectorWidthA: [8,16]
         - DepthU: [32,64,128]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -153,9 +148,6 @@ BenchmarkProblems:
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -163,11 +155,9 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #######################################
   # NT - standard
@@ -186,7 +176,7 @@ BenchmarkProblems:
       Batched: True
       Activation: True
       ActivationHPA: True
-      UseBias: True
+      UseBias: 3
       BiasDataTypeList: ['s']
 
     - # BenchmarkProblemSizeGroup - Standard
@@ -203,7 +193,7 @@ BenchmarkProblems:
           - [32, 32, 32, 1,  1,  7, 2,  1, 4 ]
         - GlobalReadVectorWidthA: [8]
         - DepthU: [32,64,128]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -230,9 +220,6 @@ BenchmarkProblems:
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -240,11 +227,9 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #######################################
   # TT - standard
@@ -263,7 +248,7 @@ BenchmarkProblems:
       Batched: True
       Activation: True
       ActivationHPA: True
-      UseBias: True
+      UseBias: 3
       BiasDataTypeList: ['s']
 
     - # BenchmarkProblemSizeGroup - Standard
@@ -280,7 +265,7 @@ BenchmarkProblems:
           - [32, 32, 32, 1,  1,  7, 2,  1, 4 ]
         - GlobalReadVectorWidthA: [8]
         - DepthU: [32,64,128]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -307,9 +292,6 @@ BenchmarkProblems:
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -317,8 +299,6 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]

--- a/tensilelite/Tensile/Tests/common/sparse/spmm_i8hs_sb.yaml
+++ b/tensilelite/Tensile/Tests/common/sparse/spmm_i8hs_sb.yaml
@@ -32,7 +32,7 @@ BenchmarkProblems:
       Batched: True
       Activation: True
       ActivationHPA: True
-      UseBias: True
+      UseBias: 3
       BiasDataTypeList: ['s']
 
     - # BenchmarkProblemSizeGroup - Standard
@@ -49,7 +49,7 @@ BenchmarkProblems:
           - [32, 32, 32, 1,  1,  7, 2,  1, 4 ]
         - GlobalReadVectorWidthB: [8]
         - DepthU: [32,64,128]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -77,9 +77,6 @@ BenchmarkProblems:
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -87,11 +84,10 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
         - BiasTypeArgs: ['s']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #########################################
   ## TN - standard
@@ -110,7 +106,7 @@ BenchmarkProblems:
       Batched: True
       Activation: True
       ActivationHPA: True
-      UseBias: True
+      UseBias: 3
       BiasDataTypeList: ['s']
 
     - # BenchmarkProblemSizeGroup - Standard
@@ -127,7 +123,7 @@ BenchmarkProblems:
           - [32, 32, 32, 1,  1,  7, 2,  1, 4 ]
         - GlobalReadVectorWidthB: [8,16]
         - DepthU: [32,64,128]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -155,9 +151,6 @@ BenchmarkProblems:
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -165,11 +158,10 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
         - BiasTypeArgs: ['s']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #######################################
   # NT - standard
@@ -188,7 +180,7 @@ BenchmarkProblems:
       Batched: True
       Activation: True
       ActivationHPA: True
-      UseBias: True
+      UseBias: 3
       BiasDataTypeList: ['s']
 
     - # BenchmarkProblemSizeGroup - Standard
@@ -205,7 +197,7 @@ BenchmarkProblems:
           - [32, 32, 32, 1,  1,  7, 2,  1, 4 ]
         - GlobalReadVectorWidthB: [8]
         - DepthU: [32,64,128]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -233,9 +225,6 @@ BenchmarkProblems:
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -243,11 +232,10 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
         - BiasTypeArgs: ['s']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]
 
   #######################################
   # TT - standard
@@ -266,7 +254,7 @@ BenchmarkProblems:
       Batched: True
       Activation: True
       ActivationHPA: True
-      UseBias: True
+      UseBias: 3
       BiasDataTypeList: ['s']
 
     - # BenchmarkProblemSizeGroup - Standard
@@ -283,7 +271,7 @@ BenchmarkProblems:
           - [32, 32, 32, 1,  1,  7, 2,  1, 4 ]
         - GlobalReadVectorWidthB: [8]
         - DepthU: [32,64,128]
-        - TransposeLDS: [0,1]
+        - TransposeLDS: [-1]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - LdsPadMetadata: [-1]
@@ -311,9 +299,6 @@ BenchmarkProblems:
           - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 96] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 136] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -321,8 +306,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 96] # classic format
           - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 136] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
         - BiasTypeArgs: ['s']
+        - BiasDimArgs: [0, 1]
         - ActivationArgs:
           - [Enum: none]
-          - [Enum: tanh]

--- a/tensilelite/Tensile/Tests/common/sparse/use_sgpr_for_gro.yaml
+++ b/tensilelite/Tensile/Tests/common/sparse/use_sgpr_for_gro.yaml
@@ -108,14 +108,14 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 136] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -202,14 +202,14 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 136] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -297,14 +297,14 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 136] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -392,14 +392,14 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 136] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -485,14 +485,14 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 136] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -576,14 +576,14 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 136] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -670,14 +670,14 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 136] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -762,14 +762,14 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 136] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format

--- a/tensilelite/Tensile/Tests/common/sparse/use_sgpr_for_gro_sb.yaml
+++ b/tensilelite/Tensile/Tests/common/sparse/use_sgpr_for_gro_sb.yaml
@@ -108,14 +108,14 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 136] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -202,14 +202,14 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 136] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -297,14 +297,14 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 136] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -392,14 +392,14 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 136] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -485,14 +485,14 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 136] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -576,14 +576,14 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 136] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -670,14 +670,14 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 136] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format
@@ -762,14 +762,14 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [15, 15, 1, 16] # classic format
-          - Exact: [15, 15, 1, 32] # classic format
-          - Exact: [15, 15, 1, 64] # classic format
-          - Exact: [15, 15, 1, 96] # classic format
-          - Exact: [15, 15, 1, 128] # classic format
-          - Exact: [15, 15, 1, 136] # classic format
-          - Exact: [15, 15, 1, 256] # classic format
-          - Exact: [15, 15, 1, 264] # classic format
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 136] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 264] # classic format
           - Exact: [256, 256, 1, 16] # classic format
           - Exact: [256, 256, 1, 24] # classic format
           - Exact: [256, 256, 1, 32] # classic format


### PR DESCRIPTION
To extend the parameter "UseBias" to support bias vector on M, N directions

-  0=No bias, 1=Bias at  M direction, 2=Bias at  N direction, 3=Bias at M or N direction
-  tag in kernel name, 1=*_Bias_*, 2=*_Bias_BDN_*, 3=*_Bias_BDMN_*